### PR TITLE
chore: rename writing-coach → writer

### DIFF
--- a/.claude/agents/writer.md
+++ b/.claude/agents/writer.md
@@ -1,5 +1,5 @@
 ---
-name: writing-coach
+name: writer
 description: McKinsey-level writing review. Communication drafts, LinkedIn articles, presentation outlines. Structured feedback on clarity, structure, and persuasiveness.
 model: sonnet
 tools: Read, Write, Edit, Grep, Glob

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Agent frontmatter specifies the model. The orchestrator MUST use the specified m
 | designer | Sonnet | Design reasoning |
 | product-strategist | Opus | Market analysis needs strongest reasoning |
 | product-tactician | Sonnet | Feature scoping |
-| writing-coach | Sonnet | Writing quality |
+| writer | Sonnet | Writing quality |
 
 **Override examples** (state the reason when overriding):
 - Researcher hitting complex analysis → upgrade to Sonnet

--- a/scripts/sync-agentic.sh
+++ b/scripts/sync-agentic.sh
@@ -11,7 +11,7 @@ MACBOOK="$SCRIPT_DIR"
 source "$MACBOOK/.personal/config.sh" 2>/dev/null || true
 
 # Shared agents (canonical source: .claude/agents/)
-SHARED_AGENTS=(researcher planner implementer reviewer product-strategist product-tactician designer writing-coach)
+SHARED_AGENTS=(researcher planner implementer reviewer product-strategist product-tactician designer writer)
 
 # Core skills (canonical source: .claude/skills/)
 CORE_SKILLS=(commit-review product-lab deep-research security-review shell-conventions)


### PR DESCRIPTION
## Summary
Rename `writing-coach.md` → `writer.md` for naming consistency. All shared agents are now single nouns: researcher, planner, implementer, reviewer, designer, writer.

Updated: agent file, SHARED_AGENTS array in sync-agentic.sh, model routing table in CLAUDE.md.