### PR TITLE
fix(sync): exclude node_modules from .claude discovery

### DIFF
--- a/scripts/sync-agentic.sh
+++ b/scripts/sync-agentic.sh
@@ -238,7 +238,7 @@ verify_all() {
   # Auto-discover: any repo with a .claude/ dir under repos/, any depth
   while IFS= read -r d; do
     targets+=("$d")
-  done < <(find "$ws/repos" -name ".claude" -type d -exec dirname {} \; 2>/dev/null)
+  done < <(find "$ws/repos" -name "node_modules" -prune -o -name ".claude" -type d -print 2>/dev/null | xargs -I{} dirname {})
 
   for target in "${targets[@]}"; do
     # Skip the canonical source — its agents are regular files by design


### PR DESCRIPTION
## Summary
- sync-agentic.sh `--verify` was scanning into `node_modules/` subdirectories that contain `.claude` dirs (e.g., `es-abstract`, `resolve`)
- These false positives reported 16+ missing agent symlinks that don't actually exist
- Fix: add `-name "node_modules" -prune` to the `find` command

## Test plan
- [ ] `bash scripts/sync-agentic.sh --verify` reports 0 failures