### PR TITLE
docs(workflow): STACKED_PRS.md + session cost log + 2026-04-18 post-mortem

### DIFF
--- a/docs/CLAUDE_AGENTS.md
+++ b/docs/CLAUDE_AGENTS.md
@@ -174,6 +174,25 @@ Model routing is enforced via agent frontmatter. Each agent has a `model:` field
 
 **Override protocol**: State the reason in conversation before dispatching with a different model. Examples: "Upgrading researcher to Sonnet — this requires cross-repo analysis, not just file scanning." This creates an audit trail for cost decisions.
 
+### Session cost log
+
+At session end, append a single line to `scripts/.session-cost.log` (append-only, gitignored, reviewed at weekly review):
+
+```
+YYYY-MM-DD | <session_topic> | <dispatches> | <models_used> | <outcome>
+```
+
+Fields:
+- **date**: ISO date
+- **session_topic**: one-line summary ("/mind aspects Phase 6 B-C-D")
+- **dispatches**: agent count × tier, e.g. `Explore×3, Plan×1, impl×5` or `—` for direct work
+- **models_used**: comma-separated, deduped — `haiku,sonnet` / `sonnet,opus`
+- **outcome**: one-word rollup — `shipped`, `blocked`, `partial`, `plan-only`
+
+Not exact token counting — Claude Code doesn't expose that. Gives directional cost awareness over time. Patterns emerge at weekly review: "research-heavy sessions cost more than implementation sessions," "sessions with >10 dispatches usually needed Graphite instead of manual stacks."
+
+See [`STACKED_PRS.md`](./STACKED_PRS.md) for when manual stacking indicates missing tooling.
+
 ## Phase Skipping
 
 Not every task needs every phase. The orchestrator classifies the task first, then follows the dispatch table in CLAUDE.md.

--- a/docs/GIT-WORKFLOW.md
+++ b/docs/GIT-WORKFLOW.md
@@ -155,6 +155,8 @@ Create a workspace file to see all worktrees at once:
 
 ## Graphite CLI (Stacked PRs)
 
+**See also**: [`STACKED_PRS.md`](./STACKED_PRS.md) for the strategic view — when to stack, manual retarget fallback when `gt` isn't available, repo hygiene defaults, and the 2026-04-18 incident post-mortem.
+
 ### What is Graphite?
 Graphite enables "stacked pull requests" - breaking large changes into small, reviewable pieces that depend on each other.
 

--- a/docs/STACKED_PRS.md
+++ b/docs/STACKED_PRS.md
@@ -1,0 +1,84 @@
+# Stacked PRs — ship with Graphite
+
+## Why this doc exists
+
+When a plan produces **multiple dependent PRs** — each branched off the last, each building on the previous — shipping them as separate `gh pr create` calls creates painful merge choreography:
+
+- Each parent merge forces the child to rebase (sometimes GitHub auto-retargets the base, often it doesn't)
+- CI re-runs on every rebase
+- Reviewers see the wrong diff (child PR includes parent's commits until the parent merges)
+- **Silent failure mode**: if a child PR's base isn't retargeted before merging, it merges into the parent's feature branch instead of main (see [2026-04-18 post-mortem](#2026-04-18-incident) below)
+
+Graphite (`gt`) is purpose-built for this pattern. It tracks the stack, auto-rebases as parents merge, and shows reviewers each PR's incremental diff.
+
+## Install
+
+```bash
+brew install withgraphite/tap/graphite
+gt auth
+```
+
+Bootstrap script (`setup-macos.sh`) adds this alongside `gh`, `delta`, `fzf`, etc.
+
+## The stacked workflow
+
+```bash
+# Start a stack from main
+gt branch create feat/phase-1
+# ... make changes, commit ...
+
+gt branch create feat/phase-2
+# ... make changes, commit ...
+
+gt branch create feat/phase-3
+# ... make changes, commit ...
+
+# Submit the whole stack as coordinated PRs
+gt stack submit
+```
+
+Graphite opens one PR per branch, sets each PR's base to its parent branch, and maintains that topology as things move.
+
+## When a parent merges
+
+```bash
+gt sync
+```
+
+Graphite rebases your downstream branches onto the new main, updates the PRs' bases to `main`, and force-pushes. No manual retargeting.
+
+## Common commands
+
+| Task | Command |
+|------|---------|
+| Create a branch on top of the current one | `gt branch create <name>` |
+| Commit + continue up the stack | `gt modify --commit -m "..."` |
+| Show the current stack | `gt log short` |
+| Push the whole stack | `gt stack submit` |
+| Sync after a parent merges | `gt sync` |
+| Jump between stack branches | `gt up` / `gt down` |
+
+## When Graphite isn't installed yet — manual retarget pattern
+
+If you're mid-stack without `gt`, **always retarget each downstream PR's base to `main` before the parent merges**. GitHub doesn't do this automatically unless "Auto-delete head branches" is on AND the parent's head gets deleted via the merge.
+
+```bash
+gh pr edit <child-pr-number> --base main
+```
+
+Do this proactively for every downstream PR as soon as the parent is approved. Otherwise the merge silently lands the child into the parent's feature branch, not main — and you'll need a recovery PR to cherry-pick the squash commits onto main.
+
+## 2026-04-18 incident
+
+A 4-PR stack on `mojwang/mojwang.tech` (Phase 4 → Phase 6 → Phase 7 → Phase 8 of the `/mind` composition arc) was shipped as separate `gh pr create` PRs. PRs #64 and #65 squash-merged into their parent feature branches instead of `main` because the parent's head hadn't been deleted yet (auto-delete-head-branches was off). Recovery required PR #66 — cherry-picking the two squash commits directly onto main.
+
+**The fix for next time**: `gt stack submit` from the start. Root cause wasn't git — it was the missing stack-awareness tooling.
+
+## Repo hygiene defaults
+
+Two settings every new repo should have to make stacks safer:
+
+1. **GitHub → Settings → Pull Requests → Automatically delete head branches**: ON. Enables auto-retargeting of downstream PRs when the parent merges.
+2. **Vercel → Settings → Integrations → Neon → "Delete Neon database branch when Vercel preview is deleted"**: ON. Keeps preview-DB branches from accumulating toward the 10-branch ceiling (free tier).
+
+See `./maintenance.md` for the repo-setup checklist.


### PR DESCRIPTION
Tier 3.1 + 3.3 from the next-session plan. Flows today's workflow learnings back into the canonical agentic infra.

## Summary

**\`docs/STACKED_PRS.md\`** (new)
- Companion to the existing GIT-WORKFLOW.md Graphite tutorial
- Strategic-view: WHEN to stack, manual retarget pattern, repo hygiene defaults
- Concrete 2026-04-18 incident post-mortem (mojwang.tech PRs #64/#65)
- Cross-referenced from GIT-WORKFLOW.md

**\`docs/CLAUDE_AGENTS.md\`** — adds session-cost-log format
- \`scripts/.session-cost.log\` append-only: \`date | topic | dispatches | models | outcome\`
- Documents the weekly-review pattern-detection use case
- Cross-references STACKED_PRS.md for the "manual stacks indicate tooling gap" pattern

## Test plan
- [ ] \`docs/STACKED_PRS.md\` renders cleanly on GitHub
- [ ] Cross-reference links resolve in both directions
- [ ] No conflicts with existing Graphite docs — the new file is a strategic-view companion, not a replacement

## Pre-existing findings (no changes this PR)
- Graphite is already in \`homebrew/Brewfile\` (\`withgraphite/tap/graphite\`)
- GIT-WORKFLOW.md already has a thorough Graphite tutorial section
- So Tier 3.1's "install gt" action item is already satisfied — just the strategic doc was missing