### PR TITLE
chore(hooks): block machine-payment commands without explicit session flag

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,10 @@
           {
             "type": "command",
             "command": "bash -c 'cmd=$(jq -r \".tool_input.command\" 2>/dev/null); if echo \"$cmd\" | grep -qE \"^git commit|&& git commit|; git commit\"; then branch=$(git branch --show-current 2>/dev/null); for b in main master develop staging production; do if [ \"$branch\" = \"$b\" ]; then echo \"BLOCKED: Cannot commit to protected branch '\"'\"'$branch'\"'\"'. Create a feature branch first.\"; exit 2; fi; done; fi; exit 0'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'if [ \"$CLAUDE_ALLOW_PAYMENTS\" = \"1\" ]; then exit 0; fi; cmd=$(jq -r \".tool_input.command\" 2>/dev/null); if echo \"$cmd\" | grep -qE \"stripe\\.com|stripe-cli|@stripe/|x402[./]|@x402/|browserbase|parallel\\.ai|tempo\\.xyz\"; then echo \"BLOCKED: Machine-payment command detected (stripe/x402/browserbase/parallel.ai/tempo). Set CLAUDE_ALLOW_PAYMENTS=1 for this session to bypass — review the command first.\"; exit 2; fi; exit 0'"
           }
         ]
       }


### PR DESCRIPTION
## Context

Roadmap **P0.1** from the [2026-04-19 overnight research implementation roadmap](../../../../../Users/mojwang/ai/workspace/claude/resources/agentic-research/2026-04-19-implementation-roadmap.md). Asymmetric-risk guard, zero adoption cost.

## Why now

Stripe Machine Payments Protocol + Tempo rails went live in 2026 (source 10 in the overnight memo). Once agents can pay, the boundary between an agent's Bash call and a paid external service collapses. An autonomous \`implementer\` spawned during an overnight research session could rack up a five-figure bill while you sleep. This hook is the perimeter.

## Change

Second PreToolUse (Bash) hook in \`.claude/settings.json\` (mirror of the existing commit-to-protected-branch guard at line 33). Blocks any Bash command matching known payment surfaces unless \`CLAUDE_ALLOW_PAYMENTS=1\` is set in the session env.

**Blocked patterns** (specific enough to avoid false positives):
- \`stripe.com\`, \`stripe-cli\`, \`@stripe/*\`
- \`x402.\` domain, \`@x402/*\` scoped packages
- \`browserbase\`
- \`parallel.ai\`
- \`tempo.xyz\`

**Bypass:** set \`CLAUDE_ALLOW_PAYMENTS=1\` for the session, review the command, unset after.

## Verification

- [x] \`jq . .claude/settings.json\` → JSON valid
- [x] \`curl https://api.stripe.com/v1/charges\` → matches (BLOCKED as expected)
- [x] \`git grep stripe\` → doesn't match (ALLOWED)
- [x] \`cat docs/stripe.md\` → doesn't match (ALLOWED)
- [x] \`grep -r parallel src\` → doesn't match (ALLOWED — bare "parallel" is not a trigger)
- [x] \`CLAUDE_ALLOW_PAYMENTS=1\` → escape valve fires before pattern check

## Memory

Added \`feedback_agent_payment_policy.md\` to the persistent memory layer so the rule survives compaction and future sessions pick it up automatically.

## Out of scope

- **Adopting** MPP — this PR is the block, not the integration.
- Pattern extensions for future payment rails — tighten as they emerge.
- Any other hook work — P0.2 (session logger) is a separate PR next.