### PR TITLE
feat(grading): /grade-session command + retroactive backfill nudge

### DIFF
--- a/.claude/commands/grade-session.md
+++ b/.claude/commands/grade-session.md
@@ -1,0 +1,38 @@
+---
+description: Walk ungraded rows in scripts/.session-cost.log, prompt for an outcome grade per row, and atomically rewrite the log with grades filled in. Grades are from the enum shipped | partial | reverted | blocked | plan-only.
+allowed-tools: Bash
+---
+
+# Grade Session (retroactive)
+
+Backfill missing `outcome` values on past `/log-session` rows. Each row the logger writes without an outcome gets `| | <sha>` at the tail — those are the rows this command walks.
+
+## Run
+
+```bash
+./scripts/grade-session.sh $ARGUMENTS
+```
+
+## Behavior
+
+1. Scans `scripts/.session-cost.log` for rows whose 5th field (outcome) is empty (i.e. `| <whitespace> | <sha>` at the tail).
+2. For each ungraded row, prints it and prompts for a grade: `shipped | partial | reverted | blocked | plan-only` (or `skip` to leave it ungraded for now).
+3. Writes updates to `scripts/.session-cost.log.tmp` then atomically renames — the live log is never in a half-edited state.
+4. Skipped rows remain ungraded.
+
+## Usage
+
+```
+/grade-session              # walk all ungraded rows interactively
+/grade-session --count      # just report how many are ungraded, don't prompt
+```
+
+## Rubric (from docs/AGENT_LEARNINGS.md)
+
+- **shipped** — PR merged, feature live, no regressions. User-visible outcome.
+- **partial** — Got part of the way; ≥1 follow-up queued. Not a failure but not done.
+- **reverted** — Shipped and rolled back (within 7 days) for any reason.
+- **blocked** — External dependency, missing info, or repro-needed killed the session.
+- **plan-only** — Intentional: user asked for a plan/research, not a ship. No code outcome expected.
+
+Grades feed the P5.1 meta-agent (deferred +90 days) and weekly reviews. Grade within 24h for highest signal.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,14 @@
             "statusMessage": "Running environment health check..."
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'log=\"./scripts/.session-cost.log\"; [ -f \"$log\" ] || exit 0; n=$(awk -F\"|\" \"{ gsub(/^[ \\t]+|[ \\t]+$/, \\\"\\\", \\$5); if (\\$5 == \\\"\\\") c++ } END { print c+0 }\" \"$log\"); if [ \"$n\" -ge 3 ]; then echo \"$n ungraded sessions in .session-cost.log — run /grade-session to backfill.\"; fi'"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/docs/AGENT_LEARNINGS.md
+++ b/docs/AGENT_LEARNINGS.md
@@ -3,6 +3,44 @@
 Persistent cross-session knowledge extracted from `claude-progress.md` after each PR merge.
 Unlike ephemeral artifacts, this file lives in the repo permanently and is read at session startup.
 
+## Grading Rubric (for `/grade-session`)
+
+`/log-session` writes rows with an optional `outcome` field. `/grade-session` walks ungraded rows and fills them in retroactively. These are the enum values — pick the one that best describes the session's end state.
+
+### `shipped`
+- PR merged, feature live, no regressions within 24h.
+- User-visible outcome (code, config, or docs).
+- Follow-ups may exist, but the core work landed.
+- Use for: standard feature work that completed cleanly.
+
+### `partial`
+- Part of the stated scope landed; at least one follow-up is queued.
+- Not a failure — genuine scope trim, or a breakdown into multiple PRs.
+- Distinguish from `shipped`: if you had to defer work to a *future* PR that isn't already open, it's partial.
+- Use for: any session where the original ask has remaining work.
+
+### `reverted`
+- Shipped and rolled back within 7 days (by revert commit, re-implementation, or feature-flag disable).
+- Reason doesn't matter for the grade — the signal is the revert itself.
+- Follow-up note should name the root cause in the commit/PR body so meta-agent can find the pattern.
+- Use for: any post-ship rollback, regardless of who initiated.
+
+### `blocked`
+- External dependency, missing info, or non-reproducible bug killed the session.
+- No code shipped; would have shipped if not for the block.
+- Different from `plan-only`: `blocked` is involuntary, `plan-only` is intentional.
+- Use for: waiting on upstream fix, missing access, ambiguous spec, or flaky repro.
+
+### `plan-only`
+- User explicitly asked for a plan, research, or recommendation — not a ship.
+- No code outcome was expected; the deliverable was a document.
+- Don't use this as a fallback for "I couldn't finish" — that's `partial` or `blocked`.
+- Use for: overnight research, exec-plan writing, architecture review.
+
+### `skip` (not a grade — leaves the row ungraded)
+- Use when you genuinely don't remember the session or need to grade it later.
+- The row stays ungraded and reappears next run of `/grade-session`.
+
 ## Failure Patterns
 <!-- Format: - [Pattern]: [What went wrong] → [What works instead] (PR #XX) -->
 

--- a/scripts/grade-session.sh
+++ b/scripts/grade-session.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Retroactively grade rows in scripts/.session-cost.log whose outcome
+# field is empty. Writes to a temp file + mv to guarantee atomicity —
+# a partial rewrite can never leave the live log in a half-edited state.
+#
+# Companion to /log-session (P0.2). Roadmap: P0.3 from 2026-04-19.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_PATH="$REPO_ROOT/scripts/.session-cost.log"
+
+COUNT_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --count) COUNT_ONLY=1; shift ;;
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "$0") [--count]
+
+Walks rows in $LOG_PATH whose outcome field (5th column) is empty and
+prompts for a grade. Grades are written via temp-then-mv for atomicity.
+
+  --count    Report the number of ungraded rows; do not prompt.
+
+Outcome enum: shipped | partial | reverted | blocked | plan-only
+(Use 'skip' to leave a row ungraded for now.)
+EOF
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$LOG_PATH" ]]; then
+    echo "No log at $LOG_PATH — nothing to grade. (Run /log-session first.)"
+    exit 0
+fi
+
+# A row is "ungraded" when field 5 (outcome) is empty. The logger
+# always writes exactly " | " between fields; an empty outcome therefore
+# appears as "|  |" at that column boundary. Counting on awk with the
+# pipe separator is more precise than a regex against the raw string.
+is_ungraded() {
+    awk -F'|' '{
+        gsub(/^[ \t]+|[ \t]+$/, "", $5)
+        exit ($5 == "" ? 0 : 1)
+    }' <<<"$1"
+}
+
+# Gather ungraded row numbers up front so we can show progress.
+mapfile_compat() {
+    # bash 3.2 on macOS lacks `mapfile`. Use while-read instead.
+    local _line _i=0
+    while IFS= read -r _line; do
+        _i=$((_i + 1))
+        if is_ungraded "$_line"; then
+            printf '%s\n' "$_i"
+        fi
+    done < "$LOG_PATH"
+}
+
+UNGRADED_LINENOS=()
+while IFS= read -r lineno; do
+    UNGRADED_LINENOS+=("$lineno")
+done < <(mapfile_compat)
+
+UNGRADED_COUNT=${#UNGRADED_LINENOS[@]}
+
+if [[ $COUNT_ONLY -eq 1 ]]; then
+    echo "$UNGRADED_COUNT"
+    exit 0
+fi
+
+if [[ $UNGRADED_COUNT -eq 0 ]]; then
+    echo "No ungraded rows in $LOG_PATH."
+    exit 0
+fi
+
+echo "Found $UNGRADED_COUNT ungraded row(s) in $LOG_PATH."
+echo "Grade enum: shipped | partial | reverted | blocked | plan-only | skip"
+echo ""
+
+# Read full log into memory. Session log is append-only and small
+# (one row per session); megabytes not in play at any realistic horizon.
+LOG_LINES=()
+while IFS= read -r _line; do
+    LOG_LINES+=("$_line")
+done < "$LOG_PATH"
+
+VALID_GRADES="shipped partial reverted blocked plan-only"
+
+updated=0
+for lineno in "${UNGRADED_LINENOS[@]}"; do
+    idx=$((lineno - 1))
+    row="${LOG_LINES[idx]}"
+    echo "[$lineno] $row"
+    while :; do
+        read -r -p "  Grade (or 'skip'): " grade </dev/tty || grade=""
+        grade="${grade// /}"
+        if [[ -z "$grade" ]]; then
+            echo "  (empty — enter a grade or 'skip')" >&2
+            continue
+        fi
+        if [[ "$grade" == "skip" ]]; then
+            break
+        fi
+        if [[ " $VALID_GRADES " == *" $grade "* ]]; then
+            # Replace field 5 in this row, preserving spacing on either
+            # side of the pipes. awk with FS="|" splits on bare pipes,
+            # but the logger writes " | " with surrounding spaces — so
+            # we need to match the logger's exact format. Use awk to
+            # rebuild the row with OFS=" | " and a trimmed-in field.
+            LOG_LINES[idx]=$(
+                awk -v g="$grade" -F'|' 'BEGIN{OFS=" | "} {
+                    for (i=1; i<=NF; i++) gsub(/^[ \t]+|[ \t]+$/, "", $i)
+                    $5 = g
+                    print
+                }' <<<"$row"
+            )
+            updated=$((updated + 1))
+            break
+        fi
+        echo "  Invalid: '$grade'. Use one of: $VALID_GRADES | skip" >&2
+    done
+done
+
+if [[ $updated -eq 0 ]]; then
+    echo "No rows updated."
+    exit 0
+fi
+
+# Atomic rewrite: write to .tmp then mv. On any crash between the two,
+# the live log is still the pre-edit file — never a half-edit.
+TMP_PATH="$LOG_PATH.tmp"
+: > "$TMP_PATH"
+for line in "${LOG_LINES[@]}"; do
+    printf '%s\n' "$line" >> "$TMP_PATH"
+done
+mv "$TMP_PATH" "$LOG_PATH"
+
+echo ""
+echo "Updated $updated row(s). Remaining ungraded: $((UNGRADED_COUNT - updated))."


### PR DESCRIPTION
## Why

Per roadmap **P0.3**. Companion to P0.2's `/log-session` (#114) — the logger writes rows with an empty `outcome` field when the grade isn't known yet; this PR lets those rows be filled in later instead of being stuck ungraded forever. Also seeds the formerly-empty `AGENT_LEARNINGS.md` with a grading rubric so future P5.1 meta-agent work has real anchors to pattern-match against.

Roadmap reference: `resources/agentic-research/2026-04-19-implementation-roadmap.md` P0.3 (lines 59–68).

## What

**`scripts/grade-session.sh`** (new, executable)
- Walks `.session-cost.log` for rows whose 5th field (outcome) is empty.
- Per row: prints it, prompts for `shipped | partial | reverted | blocked | plan-only | skip`.
- Atomic rewrite via temp-then-mv — a partial run can't leave the log in a half-edited state.
- Bash 3.2 compatible (no `mapfile` — macOS default bash is ancient). Shellcheck clean.
- `--count` flag reports ungraded count without prompting; used by the SessionStart hook.

**`.claude/commands/grade-session.md`** (new)
- Slash-command wrapper that forwards `$ARGUMENTS` to the script. Mirrors the `log-session.md → log-session.sh` pattern from P0.2.

**`docs/AGENT_LEARNINGS.md`** (seeded)
- Previously 13 lines of empty template. Added a Grading Rubric section with a paragraph per enum value describing when to use it. Preserves the existing Failure Patterns / Workflow Insights / Model Routing Outcomes placeholders.

**`.claude/settings.json`** (third SessionStart stanza)
- Counts rows where field 5 is empty. Emits `"N ungraded sessions in .session-cost.log — run /grade-session to backfill."` when count >= 3. JSON validated with `jq`.

## Test plan

- [x] `shellcheck scripts/grade-session.sh` — clean.
- [x] `jq . .claude/settings.json` — valid JSON.
- [x] Synthetic-log smoke test: 3 rows (1 graded, 2 ungraded) → ungraded count = 2.
- [x] awk rewrite preserves the logger's exact ` | ` format.
- [ ] Interactive run: grade one row, skip another, verify atomic `.tmp` swap + correct count on next run.
- [ ] SessionStart hook: verify nudge fires only when >=3 ungraded rows exist.

## Hard constraints honored

- No `Co-Authored-By` footer.
- No edits outside the four files listed above.
- `.session-cost.log` itself is `.gitignore`d — not committed.