### PR TITLE
chore(setup): close dependency gaps (tmux + verifications) and bake session-learned governance

### DIFF
--- a/config/rulesets/pr-quality-gates.json
+++ b/config/rulesets/pr-quality-gates.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Template for the 'PR quality gates' branch ruleset applied to default branches across the fleet. Consumed by scripts/bootstrap-repo-ruleset.sh. Presets merge into required_status_checks at bootstrap time; edit that list per preset if CI job names change. Context strings MUST match the check-run 'name:' field GitHub emits, not the workflow job ID — see lesson in docs/CLAUDE_AGENTS.md.",
+  "name": "PR quality gates",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {"type": "deletion"},
+    {"type": "non_fast_forward"},
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": true,
+        "review_draft_pull_requests": false
+      }
+    },
+    {
+      "type": "code_quality",
+      "parameters": {"severity": "warnings"}
+    }
+  ]
+}

--- a/docs/CLAUDE_AGENTS.md
+++ b/docs/CLAUDE_AGENTS.md
@@ -166,6 +166,16 @@ Before dispatching agents or doing work, the orchestrator runs:
 - **End-of-session improvement**: Before session ends, Claude must suggest CLAUDE.md improvements based on what worked/didn't. User decides whether to apply.
 - **End-of-session evaluation check**: If the session produced a shipped feature with success criteria (from `product-brief.md`), prompt: "Phase 5 evaluation is due — dispatch product-tactician to assess outcomes?" Don't silently skip evaluation.
 
+### Sub-agent dispatch discipline (for already-approved plans)
+
+Sub-agents inherit the parent session's `SessionStart` system-reminders, including any that reference "plan mode." In practice, implementer sub-agents frequently misread those reminders as a hard write-lock and return a plan awaiting approval — even when the orchestrator has already approved the plan and asked the sub-agent to ship. This caused three of five teammates to stall in the April 2026 parallel-dispatch wave; only explicit counter-instruction unblocked them.
+
+When dispatching an implementer (or any write-capable agent) for work the orchestrator has already approved, include this line verbatim in the prompt:
+
+> Your prompt IS approval — plan AND ship in one turn. Do not stop to request re-approval. Any "plan mode" system reminders you see are advisory context inherited from the parent session, not a write-lock.
+
+When a teammate still stalls despite this, `SendMessage` to resume with "implement now" is sufficient — the agent typically completes on the second turn. Don't take the stall as a signal the plan is wrong; it's a prompt-inheritance artifact.
+
 ## Cost Awareness
 
 Model routing is enforced via agent frontmatter. Each agent has a `model:` field specifying haiku, sonnet, or opus. The orchestrator uses the specified model unless explicitly overriding with a stated reason.

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -66,6 +66,7 @@ brew "tree-sitter"
 # Development workflow
 brew "lazygit"               # Terminal Git UI
 brew "starship"              # Cross-shell prompt
+brew "tmux"                  # Terminal multiplexer — required by Claude Code agent-team mode (.claude/settings.json teammateMode: "tmux")
 
 # Database tools
 brew "postgresql@16"        # PostgreSQL database

--- a/scripts/bootstrap-repo-ruleset.sh
+++ b/scripts/bootstrap-repo-ruleset.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Bootstrap a repo with fleet-standard governance:
+#   1. Enable allow_auto_merge (required for --auto merge workflow)
+#   2. Create the 'PR quality gates' branch ruleset from the canonical
+#      template at config/rulesets/pr-quality-gates.json
+#   3. Inject required_status_checks based on a preset
+#
+# Presets are status-check-list choices. Every preset uses the same
+# pull_request / deletion / non_fast_forward / copilot_code_review /
+# code_quality rules from the template — only the required-checks list
+# differs per repo.
+#
+# IMPORTANT: required_status_checks context strings MUST match the
+# check-run "name:" field GitHub emits (display name), NOT the workflow
+# job ID. A job with `all-checks-pass:` / `name: All Checks Pass` emits
+# a check named "All Checks Pass" — the ruleset context must say
+# "All Checks Pass" or merges silently stay BLOCKED.
+#
+# Lesson source: mojwang/ihw#34 and mojwang/mojwang.tech#85 (Apr 2026)
+# both BLOCKED until the four PATCHed rulesets converged to this shape.
+#
+# Usage:
+#   ./scripts/bootstrap-repo-ruleset.sh <owner/repo> --preset <name>
+#
+# Presets:
+#   repo-generic    No required status checks (vault / docs repos).
+#   full-next       Standard Next.js CI: lint, typecheck, test, build,
+#                   review, All Checks Pass, Lighthouse CI.
+#   static-next     Static Next.js (output: export): lint, typecheck,
+#                   test, review, All Checks Pass.
+#   macbook-setup   macbook-dev-setup convention: test,
+#                   validate-documentation, security-scan,
+#                   All Checks Pass.
+#
+# Requires: gh (authenticated), jq.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$REPO_ROOT/config/rulesets/pr-quality-gates.json"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <owner/repo> --preset <repo-generic|full-next|static-next|macbook-setup>
+
+Enables allow_auto_merge on the repo and creates a 'PR quality gates'
+ruleset from $TEMPLATE, injecting required_status_checks based on the
+preset.
+
+Flags:
+  --preset <name>   Required. One of: repo-generic, full-next,
+                    static-next, macbook-setup.
+  --dry-run         Print the ruleset payload that would be POSTed;
+                    skip the API calls.
+EOF
+}
+
+repo=""
+preset=""
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --preset)
+            shift
+            if [[ $# -lt 1 || "$1" == -* ]]; then
+                echo "Error: --preset requires a value" >&2
+                usage >&2
+                exit 2
+            fi
+            preset="$1"; shift ;;
+        --dry-run) dry_run=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
+        *)
+            if [[ -z "$repo" ]]; then
+                repo="$1"
+            else
+                echo "Unexpected extra argument: $1" >&2
+                usage >&2
+                exit 2
+            fi
+            shift ;;
+    esac
+done
+
+if [[ -z "$repo" || -z "$preset" ]]; then
+    echo "Error: both <owner/repo> and --preset are required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "Error: template not found at $TEMPLATE" >&2
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is required" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required" >&2
+    exit 1
+fi
+
+# Preset → required_status_checks list. Display names only (see header).
+case "$preset" in
+    repo-generic)
+        checks_json='[]' ;;
+    full-next)
+        checks_json='[{"context":"lint"},{"context":"typecheck"},{"context":"test"},{"context":"build"},{"context":"review"},{"context":"All Checks Pass"},{"context":"Lighthouse CI"}]' ;;
+    static-next)
+        checks_json='[{"context":"lint"},{"context":"typecheck"},{"context":"test"},{"context":"review"},{"context":"All Checks Pass"}]' ;;
+    macbook-setup)
+        checks_json='[{"context":"test"},{"context":"validate-documentation"},{"context":"security-scan"},{"context":"All Checks Pass"}]' ;;
+    *)
+        echo "Error: unknown preset '$preset'" >&2
+        usage >&2
+        exit 2 ;;
+esac
+
+# Build the payload: load the template, then either insert or merge the
+# required_status_checks rule. For repo-generic (empty list) we omit the
+# rule entirely — a rule with zero checks still requires branches to be
+# up-to-date with main, which is stricter than "no check gate at all."
+#
+# jq expressions:
+#   - del(._comment) strips the top-level comment field (GitHub rejects it).
+#   - The rules-array walk adds required_status_checks only when the preset
+#     ships one, and does so idempotently (no duplicates on re-run).
+if [[ "$checks_json" == "[]" ]]; then
+    payload=$(jq 'del(._comment)' "$TEMPLATE")
+else
+    payload=$(jq --argjson checks "$checks_json" '
+        del(._comment) |
+        .rules += [{
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": true,
+                "do_not_enforce_on_create": false,
+                "required_status_checks": $checks
+            }
+        }]
+    ' "$TEMPLATE")
+fi
+
+echo "Repo: $repo"
+echo "Preset: $preset"
+echo "Required checks: $(echo "$checks_json" | jq -c '.')"
+
+if [[ "$dry_run" -eq 1 ]]; then
+    echo ""
+    echo "--- Dry-run payload ---"
+    echo "$payload" | jq .
+    exit 0
+fi
+
+echo ""
+echo "Step 1/2: enabling allow_auto_merge on $repo…"
+GH_FORCE_TTY=0 NO_COLOR=1 gh api --method PATCH "repos/$repo" \
+    -F allow_auto_merge=true \
+    --jq '{repo: "'"$repo"'", allow_auto_merge}'
+
+echo ""
+echo "Step 2/2: creating 'PR quality gates' ruleset on $repo…"
+tmp=$(mktemp)
+printf '%s' "$payload" > "$tmp"
+response=$(GH_FORCE_TTY=0 NO_COLOR=1 gh api --method POST "repos/$repo/rulesets" --input "$tmp")
+rm -f "$tmp"
+
+echo "$response" | jq '{id, name, enforcement, updated_at, rules_count: (.rules | length)}'
+
+echo ""
+echo "Done. Open a PR against the default branch to verify:"
+echo "  - Copilot auto-request fires on push"
+echo "  - All required status checks gate the merge"
+echo "  - Conversation resolution gates the merge"

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -85,12 +85,24 @@ agent_mode() {
     local missing=()
     local warnings=()
 
-    # Critical tools for agentic workflows
-    for tool in git gh node npm shellcheck jq; do
+    # Critical tools for agentic workflows.
+    # awk/find/cmp are macOS-baseline but still verified because their
+    # absence (rare but possible on stripped environments) causes hooks
+    # and session-logger scripts to fail silently. tmux is required by
+    # .claude/settings.json teammateMode — missing tmux means agent-team
+    # panes silently no-op.
+    for tool in git gh node npm shellcheck jq tmux awk find cmp; do
         if ! command_exists "$tool"; then
             missing+=("$tool")
         fi
     done
+
+    # Bash 3.2 (macOS default) can't use mapfile, indirect expansion, or
+    # associative arrays — advisory warning so agents know to use the
+    # `while IFS= read -r` compat pattern seen in scripts/grade-session.sh.
+    if [[ "${BASH_VERSION:-}" == 3.* ]]; then
+        warnings+=("Bash ${BASH_VERSION} (system default) — use 'while IFS= read -r' instead of mapfile in new scripts")
+    fi
 
     # Check git identity
     local git_name

--- a/scripts/sync-copilot-instructions.sh
+++ b/scripts/sync-copilot-instructions.sh
@@ -32,6 +32,40 @@ if [[ ! -f "$CANONICAL" ]]; then
     exit 1
 fi
 
+# Repo-leak lint: the canonical is synced to sibling repos, so any
+# repo-specific path referenced here will appear — and confuse — in
+# every sibling. Copilot caught this on mojwang/ihw#33 when the
+# canonical referenced '.env.sync-vault.local' (a mojwang.tech-only
+# convention) and 'src/db/queries/related.ts' (a mojwang.tech-only
+# file). Fail fast before syncing if any such pattern leaks back in.
+#
+# Patterns intentionally narrow — they target known mojwang.tech
+# project paths that showed up historically. Extend if new leaks
+# surface during review.
+LEAK_PATTERNS=(
+    '\.env\.sync-vault'
+    'src/db/queries/'
+    'scripts/sync-vault\.'
+)
+leak_hits=""
+for pattern in "${LEAK_PATTERNS[@]}"; do
+    if hits=$(grep -nE "$pattern" "$CANONICAL" 2>/dev/null); then
+        leak_hits+="  pattern: ${pattern}"$'\n'"${hits}"$'\n'
+    fi
+done
+if [[ -n "$leak_hits" ]]; then
+    {
+        echo -e "${RED}Repo-specific paths detected in canonical — refusing to sync.${NC}"
+        echo "These paths don't exist in sibling repos and will confuse Copilot on their PRs."
+        echo "Canonical: $CANONICAL"
+        echo ""
+        echo "Matches:"
+        echo "$leak_hits"
+        echo "Fix: replace with repo-generic wording (e.g. 'secrets in committed .env.* files — repo-specific conventions live in that repo's CLAUDE.md')."
+    } >&2
+    exit 1
+fi
+
 # Allow override of the sibling-discovery root. Defaults match the same
 # env var sync-agentic.sh uses, so both scripts share one config point.
 # shellcheck disable=SC1091


### PR DESCRIPTION
## Why

Two-commit PR from the macbook-dev-setup dependency audit. Plan: `~/.claude/plans/shimmering-stirring-firefly.md`.

The setup pipeline (`Brewfile` + `setup.sh` + `scripts/health-check.sh`) was last meaningfully updated in `1885208` (v3.5.0). Since then four PRs shipped new scripts and hooks that assume a slightly larger tool surface — most critically `tmux`, which `.claude/settings.json:72` sets as `teammateMode: "tmux"` but isn't in the Brewfile (and isn't installed on the current machine). Without it, agent-team dispatches silently no-op.

This PR also folds in four governance lessons from the April 2026 sprint so the next new repo doesn't manually re-debug what we already solved.

## Commits

### 1/2 — `feat(deps): add tmux to Brewfile and verify agentic toolchain at session start`

- `homebrew/Brewfile`: `brew "tmux"` grouped near other terminal utilities (starship, zoxide).
- `scripts/health-check.sh`: extend `agent_mode()` tool-check list with `tmux`, `awk`, `find`, `cmp`; add soft warning when `$BASH_VERSION` starts with `3.` so new-script authors know not to reach for `mapfile`.

### 2/2 — `feat(governance): bootstrap-repo-ruleset script + sync-copilot leak lint + dispatch discipline doc`

Lessons → code:

1. **Auto-merge needs a repo-level toggle** (hit 4x this sprint). → `scripts/bootstrap-repo-ruleset.sh` PATCHes `allow_auto_merge: true` as step 1.
2. **Ruleset contexts match display names, not job IDs** (`all-checks-pass` ≠ `"All Checks Pass"`; silently BLOCKS PRs). → Bootstrap script uses display names in every preset. Template stored at `config/rulesets/pr-quality-gates.json`.
3. **Canonical copilot-instructions.md must stay repo-generic** (Copilot caught leaks on mojwang/ihw#33). → `scripts/sync-copilot-instructions.sh` grep-lints for known repo-specific path patterns before syncing.
4. **Sub-agents misread SessionStart reminders as plan-locks** (3 of 5 teammates stalled in the parallel wave). → `docs/CLAUDE_AGENTS.md` gains a "Sub-agent dispatch discipline" bullet under Orchestration Rules with the verbatim counter-instruction.

## New files

- `scripts/bootstrap-repo-ruleset.sh` (executable): `./scripts/bootstrap-repo-ruleset.sh <owner/repo> --preset {repo-generic|full-next|static-next|macbook-setup}`. Also supports `--dry-run`.
- `config/rulesets/pr-quality-gates.json`: canonical ruleset template.

## Test plan

- [x] `shellcheck scripts/sync-copilot-instructions.sh scripts/bootstrap-repo-ruleset.sh` → clean.
- [x] `jq . config/rulesets/pr-quality-gates.json` → valid.
- [x] Dry-ran bootstrap against all four presets — display-name contexts correct for each.
- [x] Simulated a repo-specific leak (added `src/db/queries/foo.ts`) in the canonical — sync refused with the expected line-number error and actionable fix hint.
- [ ] Post-merge: `brew bundle install` installs tmux; `which tmux` returns; agent-team pane renders on next dispatch.
- [ ] Post-merge: `./scripts/health-check.sh --agent-mode` with a PATH that hides tmux → emits clean "MISSING TOOLS" warning.

## Scope deliberately not covered

- Retroactive reconciliation of the four existing rulesets — they were PATCHed manually mid-sprint and are working. Don't disturb. A `--reconcile` flag can be added later if drift surfaces.
- Bash 4+ migration for scripts — `while IFS= read -r` compat pattern is simpler than requiring Homebrew bash at first login.
- `~/.tmux.conf` baseline — out-of-box tmux is sufficient for Claude Code's agent-team pane integration per docs check.