### PR TITLE
chore(ci): rename 'review' check to 'Claude Code Review'

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   review:
+    name: Claude Code Review
     runs-on: ubuntu-latest
     # Skip if Claude's own review triggered this (avoid loops)
     if: >-


### PR DESCRIPTION
Merge-box clarity. `name: Claude Code Review` added to the `review:` job in `claude-review.yml`. 'review' is not a required-status-check on this repo so no ruleset PATCH needed — pure display-name improvement.