### PR TITLE
fix(ci): remove paths-ignore on claude-review (prep for CCR-required)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,8 +3,6 @@ name: Claude Review
 on:
   pull_request:
     types: [opened, synchronize]
-    paths-ignore:
-      - ".github/workflows/**"
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
Fleet-consistency fix. mojwang/ihw and mojwang/mojwang.tech already shipped this today (PRs #35 and #86 respectively).

## Why

Shell scripts deserve the same Claude Code Review discipline as TypeScript. This PR removes `paths-ignore: [".github/workflows/**"]` so workflow-only PRs trigger review, not skip.

## Sequencing

This is prep. After merge, I'll PATCH ruleset `13815147` to add `Claude Code Review` to required_status_checks. Doing the PATCH first would block this very PR on a CCR check that can't run while paths-ignore is still in place — same bug that bit ihw#35 earlier today.

## Downstream

Open PR #108 (parallel-brew-installs) will need a rebase after the post-merge ruleset PATCH to pick up the new required check. Author-owned.