### PR TITLE
feat(local-tier): Gemma 4 31B IT via MLX + /ask-gemma + launchd auto-start

### DIFF
--- a/.claude/commands/ask-gemma.md
+++ b/.claude/commands/ask-gemma.md
@@ -1,0 +1,50 @@
+---
+description: Ad-hoc query to the local Gemma 4 31B IT server (mlx_lm.server on localhost:8080). $0/query, ~2-5s first-token, sovereignty-friendly — content never leaves the machine. Escape hatch for quick queries; critical-path integrations live inside /vault-ask, /process-inbox, /graduate-notes, /vault-brief.
+allowed-tools: Bash
+---
+
+# Ask Gemma
+
+Run the local Gemma query helper, forwarding any user-supplied args:
+
+```
+./scripts/ask-gemma.sh $ARGUMENTS
+```
+
+## Usage
+
+```
+/ask-gemma "<prompt>"
+/ask-gemma --file <path> "Summarize in one paragraph"
+/ask-gemma --system "You are a terse reviewer." "Fact-check: <claim>"
+/ask-gemma --max-tokens 20 "Count to 100"
+```
+
+## Flags
+
+- **`--file <path>`** — inject file content as a user-message prefix (the prompt becomes the question about that file).
+- **`--system "..."`** — explicit system prompt. Default is a terse, no-filler assistant.
+- **`--max-tokens N`** — cap output length. Default 1024.
+
+## Reach-for-it cases
+
+1. **Quick standalone query** — no vault, no context needed.
+2. **Summarize / rephrase a file** — `--file` pipes the file in.
+3. **Diverse second opinion on Claude's answer** — paste Claude's conclusion, ask Gemma for counter-argument.
+4. **Bulk/repetitive classification** — cheap to run 50× in a loop.
+5. **Sovereignty-sensitive drafts** — health/wealth/IHW content stays local.
+6. **When Anthropic is rate-limited or down** — degraded-mode fallback.
+
+## What it's NOT for
+
+- Multi-file code edits (Claude Code is better)
+- Vault-ask-class queries needing multi-round retrieval (use `/vault-ask`)
+- Decision triggers needing full vault context (use `/vault-ask`)
+- Anything that needs tool use (Bash, Read, Edit)
+
+## Prerequisites
+
+- mlx-lm installed (`pip3 install mlx mlx-lm`)
+- Model downloaded (`mlx-community/gemma-4-31b-it-4bit`)
+- Server running at `localhost:8080` — started via `./scripts/mlx-server-start.sh` or the `com.mojwang.mlx-server` LaunchAgent.
+- `./scripts/local-model-check.sh` passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,30 @@ Agent frontmatter specifies the model. The orchestrator MUST use the specified m
 - Simple code review → downgrade reviewer to Haiku
 - Architecture-critical planning → upgrade planner to Opus
 
+### Local tier (Gemma 4 31B IT via MLX)
+
+Free local inference on the M4 Max for cost-insensitive, sovereignty-sensitive, or throughput-heavy work. Model: `mlx-community/gemma-4-31b-it-4bit` (~18GB resident RAM, ~40–80 tok/s, ~2–5s first-token).
+
+**Surfaces today:**
+- `/ask-gemma "<prompt>"` — escape hatch for ad-hoc queries. Flags: `--file <path>`, `--system "..."`, `--max-tokens N`. See `.claude/commands/ask-gemma.md`.
+- Critical-path integrations in workspace commands (`/vault-ask`, `/process-inbox`, `/graduate-notes`, `/vault-brief`) via `--provider=local|claude|compare` flag. Claude-preserving defaults — opt-in for local/compare.
+
+**Reach-for-it cases:**
+- Short ad-hoc queries (rephrasing, classification, quick lookups)
+- Summaries of private/vault content (sovereignty — nothing leaves the machine)
+- Bulk repetitive work (tagging, scoring, first-pass classification)
+- Second opinion on Claude's answer via `/vault-ask --provider=compare`
+- Anthropic rate-limited or unavailable
+
+**Operational:**
+- Server starts automatically on login via the `com.mojwang.mlx-server` LaunchAgent (`config/launchd/com.mojwang.mlx-server.plist`).
+- Manual start: `./scripts/mlx-server-start.sh`
+- Verify: `./scripts/local-model-check.sh` — fast-fails with actionable error if unreachable.
+- Logs: `~/Library/Logs/mlx-server.log`
+
+**NOT yet supported:**
+- `provider: local` on agent frontmatter. Claude Code CLI doesn't honor that field today, so agent dispatches still route through Anthropic regardless. Command-level integration (above) is the current surface. Shared router (`scripts/model-route.sh`) is a future roadmap item — extract once a week of per-integration usage data tells us which integrations are reached for.
+
 ## Testing
 **Write tests BEFORE implementation** — especially when agents implement autonomously.
 Red-green-refactor: failing test first, minimal code to pass, then clean up.

--- a/config/launchd/com.mojwang.mlx-server.plist
+++ b/config/launchd/com.mojwang.mlx-server.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent: auto-start the local Gemma server on login.
+
+  Install once (replace ${SECOND_BRAIN_HOME} with the real path or use
+  the provided symlink helper):
+
+      cp config/launchd/com.mojwang.mlx-server.plist \
+          ~/Library/LaunchAgents/com.mojwang.mlx-server.plist
+      launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.mojwang.mlx-server.plist
+
+  Reload after script edits:
+      launchctl kickstart -k gui/$UID/com.mojwang.mlx-server
+
+  Remove:
+      launchctl bootout gui/$UID ~/Library/LaunchAgents/com.mojwang.mlx-server.plist
+      rm ~/Library/LaunchAgents/com.mojwang.mlx-server.plist
+
+  The plist references an absolute ProgramArguments path to
+  mlx-server-start.sh. Edit the path below if the repo lives
+  somewhere other than the default SECOND_BRAIN_HOME location.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mojwang.mlx-server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>exec "$HOME/ai/workspace/claude/repos/personal/macbook-dev-setup/scripts/mlx-server-start.sh"</string>
+    </array>
+
+    <!-- Run at login + keep alive. If the server crashes, restart. -->
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <!-- Throttle respawn to avoid tight crash loops. -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <!-- Logs land here (mlx-server-start.sh also appends directly). -->
+    <key>StandardOutPath</key>
+    <string>/tmp/mlx-server.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/mlx-server.stderr.log</string>
+
+    <!-- Need HOME + PATH so pyenv shims resolve. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <!-- Process limits: Gemma 4 31B IT 4-bit uses ~18GB resident RAM.
+         macOS doesn't need explicit memory limits here; this is noted
+         for anyone tuning the deployment. -->
+</dict>
+</plist>

--- a/docs/AGENT_LEARNINGS.md
+++ b/docs/AGENT_LEARNINGS.md
@@ -49,3 +49,17 @@ Unlike ephemeral artifacts, this file lives in the repo permanently and is read 
 
 ## Model Routing Outcomes
 <!-- Format: - [Task type]: [Model used] → [Result: sufficient/insufficient] (PR #XX) -->
+
+## Deferred Design Decisions
+
+### P2.1 — Agent-frontmatter `provider:` field deferred (2026-04-19)
+
+**What:** Roadmap P2.1 originally planned to add `provider: local-gemma4` (or similar) to agent frontmatter so `vault-curator`, `inbox-processor`, `writer` etc. could route through a local MLX server instead of Anthropic.
+
+**Why deferred:** Claude Code CLI's agent dispatch reads `name`, `description`, `model`, `tools` from frontmatter. Unknown fields (like a hypothetical `provider:`) are silently ignored — the dispatch always hits Anthropic regardless. A `provider:` field today would be no-op.
+
+**What shipped instead:** Command-level integration. `/ask-gemma` as an escape hatch plus `--provider=local|claude|compare` flag added to `/vault-ask`, `/process-inbox`, `/graduate-notes`, `/vault-brief`. Each is additive and flag-gated; Claude defaults preserve existing behavior.
+
+**Unblocker:** When Claude Code CLI supports provider routing (or when we add a dispatch shim that reads agent md ourselves and routes externally), the existing skill-level `--provider` plumbing extracts cleanly into an agent-level field.
+
+**Router as shared utility — also deferred:** Each of the 5 integrations duplicates ~15 lines of provider-routing logic. Tempting to extract into `scripts/model-route.sh` immediately. Deliberately NOT done — we want a week of per-integration usage data first to know which integrations are reached for and which routing patterns stabilize. Premature abstraction is the risk; 5 concrete integrations are cheap to maintain short-term.

--- a/scripts/ask-gemma.sh
+++ b/scripts/ask-gemma.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Ad-hoc local-Gemma query helper. Called by the /ask-gemma slash
+# command (see .claude/commands/ask-gemma.md). Verifies the local
+# server is up, then shells out to curl against the OpenAI-compatible
+# /v1/chat/completions endpoint.
+#
+# Flags:
+#   --file <path>     Inject file content as user-message prefix.
+#   --system "..."    Explicit system prompt (default: terse assistant).
+#   --max-tokens N    Cap output length (default 1024).
+#
+# Positional: the rest of the args form the prompt.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST="127.0.0.1"
+PORT="8080"
+# mlx_lm.server uses the model field as an HF repo identifier.
+# Passing "local" or any placeholder triggers a fetch. Must match
+# the model loaded by mlx-server-start.sh.
+MODEL="mlx-community/gemma-4-31b-it-4bit"
+
+SYSTEM_DEFAULT="You are a terse, no-filler assistant. Prefer concrete answers over hedging. If uncertain, say so in one sentence."
+SYSTEM="$SYSTEM_DEFAULT"
+FILE=""
+MAX_TOKENS=1024
+
+# Flag parsing. Unknown flags fall through to the prompt.
+# Using array-slice pattern for safe $2 access under set -u (see
+# log-session.sh for the same idiom).
+_require_value() {
+    local flag="$1"; shift
+    if [[ $# -lt 1 || "$1" == -* ]]; then
+        echo "Error: $flag requires a value" >&2
+        exit 2
+    fi
+}
+
+PROMPT_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --file)
+            _require_value "--file" "${@:2:1}"
+            FILE="$2"; shift 2 ;;
+        --system)
+            _require_value "--system" "${@:2:1}"
+            SYSTEM="$2"; shift 2 ;;
+        --max-tokens)
+            _require_value "--max-tokens" "${@:2:1}"
+            MAX_TOKENS="$2"; shift 2 ;;
+        -h|--help)
+            cat <<EOF
+Usage: $(basename "$0") [--file <path>] [--system "..."] [--max-tokens N] <prompt>
+
+Query the local Gemma 4 31B IT server at http://$HOST:$PORT.
+
+Examples:
+  $(basename "$0") "What's a good k8s HPA min-replicas heuristic?"
+  $(basename "$0") --file note.md "Summarize in one paragraph"
+  $(basename "$0") --max-tokens 20 "Count to 100"
+EOF
+            exit 0 ;;
+        *)
+            PROMPT_ARGS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#PROMPT_ARGS[@]} -eq 0 ]]; then
+    echo "Error: no prompt provided" >&2
+    echo "Usage: $(basename "$0") [flags] <prompt>" >&2
+    exit 2
+fi
+
+PROMPT="${PROMPT_ARGS[*]}"
+
+# If --file is set, prepend file content as user-message prefix.
+if [[ -n "$FILE" ]]; then
+    if [[ ! -f "$FILE" ]]; then
+        echo "Error: file not found: $FILE" >&2
+        exit 1
+    fi
+    FILE_CONTENT=$(cat "$FILE")
+    USER_MSG="Context (file: $FILE):
+---
+$FILE_CONTENT
+---
+
+$PROMPT"
+else
+    USER_MSG="$PROMPT"
+fi
+
+# Server preflight. Fast-fail with actionable error from the check script.
+if ! "$SCRIPT_DIR/local-model-check.sh"; then
+    exit 1
+fi
+
+# Build the JSON payload safely using jq (avoids shell-quoting hell
+# when prompts contain quotes, backticks, newlines, etc.).
+PAYLOAD=$(jq -n \
+    --arg model "$MODEL" \
+    --arg system "$SYSTEM" \
+    --arg user "$USER_MSG" \
+    --argjson max "$MAX_TOKENS" \
+    '{
+        model: $model,
+        messages: [
+            {role: "system", content: $system},
+            {role: "user",   content: $user}
+        ],
+        max_tokens: $max,
+        stream: false
+    }')
+
+# Query the OpenAI-compatible endpoint and extract the content.
+# Use -f to treat HTTP non-2xx as failure; -sS keeps output quiet on
+# success and shows errors on failure.
+RESPONSE=$(curl -fsS --max-time 120 \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    "http://$HOST:$PORT/v1/chat/completions")
+
+# Extract the assistant's message. Gemma (and other CoT-capable
+# models served by mlx_lm.server) produce both .choices[0].message.content
+# (final answer) and .choices[0].message.reasoning (internal chain-of-
+# thought). If max_tokens is too low the reasoning can consume the
+# entire budget, leaving content empty. Prefer content; fall back to
+# labeled reasoning; else surface raw.
+CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty' 2>/dev/null || true)
+REASONING=$(echo "$RESPONSE" | jq -r '.choices[0].message.reasoning // empty' 2>/dev/null || true)
+FINISH=$(echo "$RESPONSE" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null || true)
+
+if [[ -n "$CONTENT" ]]; then
+    printf '%s\n' "$CONTENT"
+    # If output was truncated, flag it so the caller knows to retry
+    # with a higher --max-tokens.
+    if [[ "$FINISH" == "length" ]]; then
+        echo "" >&2
+        echo "(truncated — finish_reason=length; raise --max-tokens to get the full response)" >&2
+    fi
+elif [[ -n "$REASONING" ]]; then
+    # Content empty but reasoning present — max_tokens was too tight.
+    echo "(no final answer produced; showing reasoning trace — raise --max-tokens)" >&2
+    printf '%s\n' "$REASONING"
+    exit 0
+else
+    echo "ERROR: unexpected response shape — raw:" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+fi

--- a/scripts/local-model-check.sh
+++ b/scripts/local-model-check.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify the local Gemma server is reachable at localhost:8080.
+#
+# Called by /ask-gemma and by /vault-ask (and other critical-path
+# integrations) before routing a request to local. Fast-fails with an
+# actionable message so the caller can surface it to the user.
+#
+# Exit codes:
+#   0 — server reachable, model present
+#   1 — server unreachable
+#   2 — server reachable but expected model missing
+
+set -euo pipefail
+
+HOST="127.0.0.1"
+PORT="8080"
+EXPECTED_SUBSTR="gemma"
+
+# jq is available from the Brewfile; fall back to grep if not
+# (keeps the script usable in minimal environments).
+if curl -fs --max-time 3 "http://$HOST:$PORT/v1/models" -o /tmp/.mlx-models.json 2>/dev/null; then
+    if grep -qi "$EXPECTED_SUBSTR" /tmp/.mlx-models.json; then
+        rm -f /tmp/.mlx-models.json
+        exit 0
+    fi
+    echo "ERROR: mlx_lm.server is up on $HOST:$PORT but no model matching '$EXPECTED_SUBSTR' is loaded." >&2
+    echo "Models returned:" >&2
+    cat /tmp/.mlx-models.json >&2 2>/dev/null || true
+    rm -f /tmp/.mlx-models.json
+    exit 2
+fi
+
+cat >&2 <<EOF
+ERROR: Local Gemma server not reachable at http://$HOST:$PORT
+Start it manually:
+    $(dirname "${BASH_SOURCE[0]}")/mlx-server-start.sh
+Or check launchd status:
+    launchctl list | grep -i mlx-server
+Logs: ~/Library/Logs/mlx-server.log
+EOF
+exit 1

--- a/scripts/mlx-server-start.sh
+++ b/scripts/mlx-server-start.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Start mlx_lm.server on localhost:8080 with Gemma 4 31B IT 4-bit.
+# Idempotent — no-op if the port is already serving the expected model.
+#
+# Invoked by the com.mojwang.mlx-server LaunchAgent at login, or
+# directly from the shell for ad-hoc restarts.
+#
+# Logs to ~/Library/Logs/mlx-server.log. The launchd plist also
+# captures stdout/stderr to the same file via StandardOutPath /
+# StandardErrorPath.
+
+set -euo pipefail
+
+MODEL="mlx-community/gemma-4-31b-it-4bit"
+HOST="127.0.0.1"
+PORT="8080"
+LOG_DIR="$HOME/Library/Logs"
+LOG_PATH="$LOG_DIR/mlx-server.log"
+
+mkdir -p "$LOG_DIR"
+
+# Already up? Curl the /v1/models endpoint. If it responds, we're done.
+# Don't check the model identity here — that's local-model-check.sh's
+# job; we only care that the port is serving SOMETHING.
+if curl -fs --max-time 2 "http://$HOST:$PORT/v1/models" >/dev/null 2>&1; then
+    echo "mlx_lm.server already responding on $HOST:$PORT — no-op."
+    exit 0
+fi
+
+# Resolve mlx_lm.server. When invoked by launchd, PATH is a minimal
+# set that excludes ~/.pyenv/shims/. Probe common install locations
+# explicitly before falling back to PATH.
+CANDIDATES=(
+    "$HOME/.pyenv/shims/mlx_lm.server"
+    "$HOME/.local/bin/mlx_lm.server"
+    "/opt/homebrew/bin/mlx_lm.server"
+    "/usr/local/bin/mlx_lm.server"
+)
+SERVER_BIN=""
+for candidate in "${CANDIDATES[@]}"; do
+    if [[ -x "$candidate" ]]; then
+        SERVER_BIN="$candidate"
+        break
+    fi
+done
+# Last-resort PATH lookup (works when invoked from an interactive shell).
+if [[ -z "$SERVER_BIN" ]]; then
+    SERVER_BIN="$(command -v mlx_lm.server || true)"
+fi
+if [[ -z "$SERVER_BIN" ]]; then
+    echo "ERROR: mlx_lm.server not found in PATH or known install locations" >&2
+    echo "Checked: ${CANDIDATES[*]}" >&2
+    echo "Install: pip3 install mlx mlx-lm" >&2
+    exit 1
+fi
+echo "Using: $SERVER_BIN"
+
+echo "Starting mlx_lm.server with model=$MODEL host=$HOST port=$PORT"
+echo "Log: $LOG_PATH"
+
+# Exec so launchd (and manual invocations) can track the process.
+# --trust-remote-code is required by some HF models; Gemma 4 doesn't
+# need it but including for forward compat. --host 127.0.0.1 binds
+# loopback only — no LAN exposure.
+exec "$SERVER_BIN" \
+    --model "$MODEL" \
+    --host "$HOST" \
+    --port "$PORT" \
+    >> "$LOG_PATH" 2>&1


### PR DESCRIPTION
## Why

Per roadmap **P2.1** — local inference tier on the M4 Max for cost-insensitive / sovereignty-sensitive / throughput-heavy work. This PR ships the infra + escape-hatch surface. Critical-path integrations (`/vault-ask`, `/process-inbox`, `/graduate-notes`, `/vault-brief`) follow in a second PR against the workspace repo.

## What ships

| File | Purpose |
|---|---|
| `scripts/mlx-server-start.sh` | Idempotent `mlx_lm.server` launcher. Probes pyenv shims first (launchd's PATH excludes them) then falls back to Homebrew locations. |
| `scripts/local-model-check.sh` | Server preflight. Called by `/ask-gemma` and future critical-path integrations. Actionable error on failure. |
| `scripts/ask-gemma.sh` | Query helper. Flags: `--file <path>`, `--system "..."`, `--max-tokens N`. Handles Gemma's `content` + `reasoning` split (falls back to reasoning with a hint when max-tokens trips early). |
| `config/launchd/com.mojwang.mlx-server.plist` | User LaunchAgent. Auto-starts on login. `KeepAlive` on non-successful-exit. `ThrottleInterval=30` to avoid crash loops. |
| `.claude/commands/ask-gemma.md` | Slash-command wrapper, mirrors `log-session.md` pattern. Documents reach-for-it cases. |
| `CLAUDE.md` | Local tier subsection under Model Routing. Surfaces, operational commands, explicit deferral of agent-frontmatter `provider:` support. |
| `docs/AGENT_LEARNINGS.md` | Rationale for the provider-field defer + for not prematurely extracting the shared router utility. |

## Strategic context

- Claude Code CLI's agent dispatch ignores unknown frontmatter fields. A `provider: local` field on agents today would be no-op. **Command-level integration is the current surface.**
- Five integration points (this PR + 4 in the next) duplicate ~15 lines of routing logic each. Extraction into `scripts/model-route.sh` is deliberately deferred until a week of usage data tells us which integrations people reach for.

## Test plan

- [x] `shellcheck scripts/*.sh` → clean
- [x] `plutil -lint config/launchd/com.mojwang.mlx-server.plist` → OK
- [x] `./scripts/mlx-server-start.sh` → server up in ~3s
- [x] `./scripts/local-model-check.sh` → returns 0 when up, 1 when port closed, 2 when wrong model
- [x] `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.mojwang.mlx-server.plist` → plist loads
- [x] `launchctl kickstart -k gui/$UID/com.mojwang.mlx-server` → server restarts cleanly
- [x] `./scripts/ask-gemma.sh "In 5 words, what model are you?"` → Gemma response in <5s
- [x] `--file` injection works end-to-end
- [x] `--max-tokens` cap trips the reasoning-truncation fallback correctly
- [ ] Reboot test: survives log-out / log-in (LaunchAgent spec covers this; not exercised in CI)

## Not in this PR (explicit defers)

- Agent-frontmatter `provider:` routing — blocked on Claude Code CLI support
- Shared router utility — deferred 1 week for usage-data signal
- `/vault-ask`, `/process-inbox`, `/graduate-notes`, `/vault-brief` integrations — follow-up PR against workspace repo