### PR TITLE
refactor(agents): upgrade researcher default to sonnet

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
-description: Deep codebase exploration before planning. Use for any task touching 3+ files.
-model: haiku
+description: Deep codebase exploration before planning. Use for any task touching 3+ files. Research is the highest-leverage step — a bad line of research compounds into bad plans and bad code. Default Sonnet; downgrade to Haiku only for explicitly broad keyword sweeps or low-stakes glob-heavy scans where breadth matters more than depth.
+model: sonnet
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Agent frontmatter specifies the model. The orchestrator MUST use the specified m
 
 | Agent | Model | Rationale |
 |-------|-------|-----------|
-| researcher | Haiku | Broad scans, cheap exploration |
+| researcher | Sonnet | Research is the highest-leverage step; compounds into plan and code quality. Haiku is an explicit override for broad scans. |
 | planner | Sonnet | Structured reasoning, good balance |
 | implementer | Sonnet | Code generation, standard tasks |
 | reviewer | Sonnet | Skeptical evaluation |
@@ -209,7 +209,7 @@ Agent frontmatter specifies the model. The orchestrator MUST use the specified m
 | writer | Sonnet | Writing quality |
 
 **Override examples** (state the reason when overriding):
-- Researcher hitting complex analysis → upgrade to Sonnet
+- Researcher doing broad keyword sweep across dozens of files → downgrade to Haiku (breadth > depth)
 - Simple code review → downgrade reviewer to Haiku
 - Architecture-critical planning → upgrade planner to Opus
 

--- a/docs/CLAUDE_AGENTS.md
+++ b/docs/CLAUDE_AGENTS.md
@@ -29,7 +29,7 @@ All agent definitions live in `.claude/agents/`. Each file uses YAML frontmatter
 
 ### Researcher (`.claude/agents/researcher.md`)
 - **Purpose**: Deep codebase exploration before planning
-- **Model**: haiku | **Tools**: Read, Grep, Glob, Bash
+- **Model**: sonnet (default — research is highest-leverage; downgrade to haiku for broad scans) | **Tools**: Read, Grep, Glob, Bash
 - **When**: Any task touching 3+ files, or unfamiliar code areas
 - **Input**: Task description from orchestrator
 - **Output**: `research.md` — current state, patterns, dependencies, risks, open questions
@@ -182,7 +182,7 @@ Model routing is enforced via agent frontmatter. Each agent has a `model:` field
 
 **Cost hierarchy**: Haiku (cheapest, exploration) → Sonnet (default, most tasks) → Opus (expensive, strategic reasoning).
 
-**Override protocol**: State the reason in conversation before dispatching with a different model. Examples: "Upgrading researcher to Sonnet — this requires cross-repo analysis, not just file scanning." This creates an audit trail for cost decisions.
+**Override protocol**: State the reason in conversation before dispatching with a different model. Examples: "Downgrading researcher to Haiku — this is a broad keyword sweep across dozens of files; breadth matters more than depth here." This creates an audit trail for cost decisions.
 
 ### Session cost log
 


### PR DESCRIPTION
## Summary

Flips the researcher agent's default model from **haiku → sonnet**, per Horthy's *Advanced Context Engineering for Coding Agents* leverage argument: **research is the highest-leverage step** — a bad line of research compounds into bad plans and thousands of bad lines of code. Cheaping out on the first step fails the rest of the pipeline.

Haiku remains available as an **explicit override** for broad keyword sweeps and low-stakes glob-heavy scans where breadth beats depth. Override-protocol example inverted accordingly.

## Changes

- `.claude/agents/researcher.md` — frontmatter `model: haiku` → `sonnet`; description updated with leverage framing + Haiku-as-override guidance
- `CLAUDE.md` — Model Routing table row + override example inverted
- `docs/CLAUDE_AGENTS.md` — Researcher section model line + override protocol example

## Cost impact

- Researcher turns are short; projected monthly delta at current dispatch volume: **under \$10**
- Tracked via session-logger `models` column over a 2-week window

## Success signal (2 weeks)

- Downstream plans cite cleaner research findings
- Fewer "threw out research and restarted" sessions (Horthy's BAML failure mode)
- Subjective sharpness of research outputs

If the signal doesn't hold, this is reversible in one commit.

## Test plan

- [x] Researcher frontmatter validates (YAML parses; required fields present)
- [x] Model Routing table still renders as a valid markdown table
- [x] Override protocol example is consistent across CLAUDE.md and docs/CLAUDE_AGENTS.md
- [ ] Next researcher dispatch in a real session logs `model: sonnet`