### PR TITLE
chore(workflow): add cross-repo decision-capture pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,10 @@ Red-green-refactor: failing test first, minimal code to pass, then clean up.
 2. **Taskmaster**: Direct task management commands via MCP (`task-master list`, `task-master next`). Task tracking and breakdown only — product thinking is handled by the native `product-tactician` and `product-strategist` agents.
 3. **Exa**: General web research (fallback for non-code queries)
 
+## Decision Capture
+
+When a non-trivial decision ships in this repo (build-vs-buy, scope-cut, technical-direction-change, agentic-infra trade-off), capture it to the workspace inbox per the full protocol in `~/ai/workspace/claude/CLAUDE.md` § Cross-repo decision capture. Drop `_inbox/notes/decision-YYYYMMDD-<slug>.md` using the decision-record template; the inbox-processor fast lane routes it priority-7 on next `/process-inbox`. Keeps decisions and their outcomes accumulating into the vault rather than scattered across commits.
+
 ## Important
 - Do only what's asked; nothing more
 - Check CI before merging: requires passing tests


### PR DESCRIPTION
## Summary

Pillar 6 of closed-loop intelligence layer Phase 2 — propagate the cross-repo decision-capture protocol to the agentic-infra repo so decisions made in *this* repo (agent design, hook changes, skill additions) accumulate into the vault inbox via the priority-7 fast lane.

Single 4-line addition. Points to canonical protocol in workspace CLAUDE.md rather than duplicating the 30-line snippet — matches the symlink architecture pattern (single source of truth in workspace, repos reference).

## Test plan
- [ ] Drop a real \`_inbox/notes/decision-YYYYMMDD-<slug>.md\` from a session in this repo
- [ ] Run \`/process-inbox\` from workspace and confirm priority-7 routing