### PR TITLE
fix(sync): rename advisors → boardroom in SHARED_COMMANDS list

### DIFF
--- a/scripts/sync-agentic.sh
+++ b/scripts/sync-agentic.sh
@@ -20,7 +20,7 @@ CORE_SKILLS=(commit-review decision-lab deep-research security-review shell-conv
 WEB_SKILLS=(doc-garden design-review design-elevation web-review typescript-conventions entropy-scan init-design-system competitive-audit)
 
 # Shared commands (canonical source: .claude/commands/)
-SHARED_COMMANDS=(deep-research decision-lab advisors)
+SHARED_COMMANDS=(deep-research decision-lab boardroom)
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
Follow-up to PR #125. The sync-agentic.sh `SHARED_COMMANDS` array still pointed at the old `advisors.md` filename. One-line fix; no logic change.