### PR TITLE
docs(skills): address rename drift Copilot caught on PR #125

### DIFF
--- a/.claude-agents.json
+++ b/.claude-agents.json
@@ -1,21 +1,21 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "project": "macbook-dev-setup",
-  "description": "Structured metadata for the 7 native sub-agents",
+  "description": "Structured metadata for the 11 native sub-agents",
 
   "agents": {
-    "product-strategist": {
-      "name": "Product Strategist",
+    "strategist": {
+      "name": "Strategist",
       "description": "Full-lifecycle product strategist. Idea validation, discovery, MVP, PMF, positioning, growth.",
       "enabled": true,
       "priority": "high",
       "tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "WebSearch", "WebFetch"],
       "triggers": ["new_product_idea", "market_validation", "pmf_assessment", "positioning"],
-      "outputs": ["product-lab/"]
+      "outputs": ["decision-lab/"]
     },
 
-    "product-tactician": {
-      "name": "Product Tactician",
+    "tactician": {
+      "name": "Tactician",
       "description": "Per-feature product thinking. Defines problems, scopes solutions, prioritizes work, and evaluates outcomes.",
       "enabled": true,
       "priority": "high",
@@ -29,7 +29,7 @@
       "description": "Deep codebase exploration before planning. Use for any task touching 3+ files.",
       "enabled": true,
       "priority": "high",
-      "model": "haiku",
+      "model": "sonnet",
       "tools": ["Read", "Grep", "Glob", "Bash"],
       "triggers": ["complex_task", "unfamiliar_code", "multi_file_change"],
       "outputs": ["research.md"]
@@ -74,13 +74,54 @@
       "tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
       "triggers": ["ui_change", "design_task", "visual_qa", "new_page"],
       "outputs": ["design-spec.md", "design_review"]
+    },
+
+    "writer": {
+      "name": "Writer",
+      "description": "McKinsey-level writing review. Communication drafts, LinkedIn articles, presentation outlines.",
+      "enabled": true,
+      "priority": "medium",
+      "tools": ["Read", "Write", "Edit", "Grep", "Glob"],
+      "triggers": ["writing_review", "communication_draft", "presentation_outline"],
+      "outputs": ["writing_review"]
+    },
+
+    "boardroom": {
+      "name": "Boardroom",
+      "description": "Convenes a curated council of operating wisdom to stress-test ideas, decisions, and exploratory thinking.",
+      "enabled": true,
+      "priority": "medium",
+      "model": "opus",
+      "tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "Task"],
+      "triggers": ["stress_test", "decision_pressure_test", "exploratory_kernel", "adversarial_critique"],
+      "outputs": ["decision-lab/board-of-advisors/"]
+    },
+
+    "skeptic": {
+      "name": "Skeptic",
+      "description": "Adversarial critique on demand — pre-ship pressure-testing to surface assumptions and failure modes.",
+      "enabled": true,
+      "priority": "medium",
+      "tools": ["Read", "Grep", "Glob"],
+      "triggers": ["pre_ship_review", "decision_critique", "challenge_assumptions"],
+      "outputs": ["skeptic_review"]
+    },
+
+    "reflector": {
+      "name": "Reflector",
+      "description": "Extract non-obvious lessons from recent activity for capture into reflection notes.",
+      "enabled": true,
+      "priority": "low",
+      "tools": ["Read", "Grep", "Glob"],
+      "triggers": ["post_session_reflection", "lessons_capture", "weekly_review"],
+      "outputs": ["reflection_notes"]
     }
   },
 
   "workflows": {
     "standard": {
-      "description": "Sequential workflow: product-tactician → research → plan → implement → review",
-      "phases": ["product-tactician", "researcher", "planner", "implementer", "reviewer"]
+      "description": "Sequential workflow: tactician → research → plan → implement → review",
+      "phases": ["tactician", "researcher", "planner", "implementer", "reviewer"]
     },
 
     "parallel_implementation": {
@@ -110,13 +151,13 @@
     "product_aware": {
       "description": "Full product-led workflow with strategy, define, and evaluate phases",
       "phases": {
-        "strategy": "product-strategist",
-        "define": "product-tactician",
+        "strategy": "strategist",
+        "define": "tactician",
         "research": { "parallel": true, "agents": ["researcher", "designer"] },
         "plan": "planner",
         "implement": { "parallel": true, "agent": "implementer", "max_concurrent": 3 },
         "review": { "parallel": true, "agents": ["reviewer", "designer"] },
-        "evaluate": "product-tactician"
+        "evaluate": "tactician"
       }
     }
   },
@@ -131,7 +172,7 @@
   "quality_gates": {
     "pre_pr": {
       "required_agents": ["reviewer"],
-      "optional_agents": ["designer"],
+      "optional_agents": ["designer", "skeptic"],
       "failure_blocks_pr": true
     }
   },

--- a/.claude/skills/decision-lab/ARTIFACTS.md
+++ b/.claude/skills/decision-lab/ARTIFACTS.md
@@ -1,6 +1,6 @@
 # Artifact Templates
 
-Templates for every document the product strategist produces. All artifacts are written to the `decision-lab/` directory. They are persistent across sessions — not ephemeral like `research.md` or `plan.md`.
+Templates for every document the strategist agent produces. All artifacts are written to the `decision-lab/` directory. They are persistent across sessions — not ephemeral like `research.md` or `plan.md`.
 
 ---
 

--- a/.claude/skills/decision-lab/COUNCIL.md
+++ b/.claude/skills/decision-lab/COUNCIL.md
@@ -707,4 +707,4 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
 
 ## Candidate pool
 
-The candidate pool is admitted with thinner schema. Each candidate gets `id`, `source`, `category`, `status: candidate`, and a one-line `value-add` hint. Full schema is expanded the first time the candidate is summoned. The pool is appended to the same `yaml` block above (continued in Task 2).
+The candidate pool is admitted with thinner schema. Each candidate gets `id`, `source`, `category`, `status: candidate`, and a one-line `value-add` hint. Full schema is expanded the first time the candidate is summoned. The pool is appended to the same `yaml` block above.

--- a/.claude/skills/decision-lab/FRAMEWORKS.md
+++ b/.claude/skills/decision-lab/FRAMEWORKS.md
@@ -1,6 +1,6 @@
 # Product Strategy Frameworks
 
-Operational knowledge for the product strategist. These are decision tools — apply them through questions and analysis, never cite them by name in conversation.
+Operational knowledge for the strategist agent. These are decision tools — apply them through questions and analysis, never cite them by name in conversation.
 
 ## Idea Evaluation Engine
 

--- a/.claude/skills/decision-lab/STAGE-PLAYBOOKS.md
+++ b/.claude/skills/decision-lab/STAGE-PLAYBOOKS.md
@@ -1,6 +1,6 @@
 # Stage Playbooks
 
-Per-stage decision logic for the product strategist. Each stage has clear entry conditions, a central question, activities, and evidence gates that must be met before advancing.
+Per-stage decision logic for the strategist agent. Each stage has clear entry conditions, a central question, activities, and evidence gates that must be met before advancing.
 
 ---
 

--- a/.claude/skills/init-project/SKILL.md
+++ b/.claude/skills/init-project/SKILL.md
@@ -28,7 +28,7 @@ claude-init-agentic --init $ARGUMENTS
    - Git repository (initialized if new)
    - `CLAUDE.md` (from template — enforced git workflow, CI section)
    - `README.md` (skeleton if not present)
-   - `.claude/agents/` (product-tactician, researcher, planner, implementer, reviewer, designer)
+   - `.claude/agents/` (boardroom, designer, implementer, planner, reflector, researcher, reviewer, skeptic, strategist, tactician, writer)
    - `.claude/skills/` (base + type-specific skills)
    - `.claude/settings.json` (type-specific hooks, merged with existing)
    - `.claude-agents.json` (only if not present)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
 
     - name: Validate Agent Definitions
       run: |
-        echo "Validating 7-agent definitions..."
-        for agent in product-strategist product-tactician researcher planner implementer reviewer designer; do
+        echo "Validating agent definitions..."
+        for agent in boardroom designer implementer planner reflector researcher reviewer skeptic strategist tactician writer; do
           if [[ -f ".claude/agents/${agent}.md" ]]; then
             echo "✓ ${agent} agent definition exists"
           else

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,7 +117,7 @@ macbook-dev-setup/
 The project uses an orchestrator pattern for complex development tasks:
 
 - **Main Claude session** acts as orchestrator — dispatches sub-agents, never implements complex tasks directly
-- **7 native agents** in `.claude/agents/`: product-strategist → product-tactician → researcher → planner → implementer → reviewer → designer
+- **11 native agents** in `.claude/agents/`: standard pipeline runs `tactician → researcher → planner → implementer → reviewer`; full roster also includes `boardroom`, `designer`, `reflector`, `skeptic`, `strategist`, `writer`
 - **Worktree isolation**: Each implementer runs in its own git worktree, enabling parallel-safe execution
 - **Checkpoint commits**: One commit per completed task for easy rollback (slot machine rule: revert > fix)
 - **Ephemeral artifacts**: `product-brief.md` → `research.md` / `design-spec.md` → `plan.md` → implementation → review. Gitignored, cleaned up after PR merge.

--- a/docs/design/agentic-design-integration.md
+++ b/docs/design/agentic-design-integration.md
@@ -4,7 +4,7 @@ How the designer agent collaborates with engineering agents as a first-class pee
 
 ## Architecture
 
-The designer is one of 7 agents in `.claude/agents/` (product-strategist, product-tactician, researcher, planner, implementer, reviewer, designer). It produces design artifacts; engineering agents consume them.
+The designer is one of 11 agents in `.claude/agents/` (boardroom, designer, implementer, planner, reflector, researcher, reviewer, skeptic, strategist, tactician, writer). It produces design artifacts; engineering agents consume them.
 
 Key principle: **agents are execution roles, skills are deployment units**. The designer agent *uses* design skills (design-review, init-design-system, competitive-audit) the same way the reviewer uses security-review.
 

--- a/scripts/claude-agents/agent-benchmarks.sh
+++ b/scripts/claude-agents/agent-benchmarks.sh
@@ -159,13 +159,13 @@ generate_report() {
     local report_data=$(cat <<EOF
 {
   "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-  "architecture": "7-agent (product-strategist, product-tactician, researcher, planner, implementer, reviewer, designer)",
+  "architecture": "11-agent (boardroom, designer, implementer, planner, reflector, researcher, reviewer, skeptic, strategist, tactician, writer)",
   "system": {
     "os": "$(uname -s)",
     "arch": "$(uname -m)",
     "cores": $(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 1)
   },
-  "agents": ["product-strategist", "product-tactician", "researcher", "planner", "implementer", "reviewer", "designer"],
+  "agents": ["boardroom", "designer", "implementer", "planner", "reflector", "researcher", "reviewer", "skeptic", "strategist", "tactician", "writer"],
   "recommendations": [
     "Run multiple implementers in parallel for independent tasks",
     "Skip researcher phase for well-understood areas",
@@ -179,13 +179,17 @@ EOF
         json)  echo "$report_data" ;;
         csv)
             echo "Agent,Role,Isolation"
-            echo "product-strategist,strategy,none"
-            echo "product-tactician,discovery,none"
-            echo "researcher,exploration,none"
-            echo "planner,planning,none"
-            echo "implementer,execution,worktree"
-            echo "reviewer,verification,none"
+            echo "boardroom,advisory,none"
             echo "designer,design,none"
+            echo "implementer,execution,worktree"
+            echo "planner,planning,none"
+            echo "reflector,reflection,none"
+            echo "researcher,exploration,none"
+            echo "reviewer,verification,none"
+            echo "skeptic,critique,none"
+            echo "strategist,strategy,none"
+            echo "tactician,discovery,none"
+            echo "writer,writing,none"
             ;;
         table|*)
             echo "╔════════════════╤═══════════════╤═══════════╗"

--- a/scripts/claude-agents/agent-benchmarks.sh
+++ b/scripts/claude-agents/agent-benchmarks.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Agent Benchmarks Script
-# Performance testing for the 6-agent orchestration pattern
+# Performance testing for the 11-agent orchestration pattern
 
 source "$(dirname "$0")/../../lib/common.sh"
 
@@ -13,7 +13,7 @@ OUTPUT_FORMAT="${OUTPUT_FORMAT:-table}"
 print_banner() {
     echo ""
     echo "┌─────────────────────────────────────────────┐"
-    echo "│   Agent Performance Benchmarks (6-Agent)    │"
+    echo "│   Agent Performance Benchmarks (11-Agent)   │"
     echo "└─────────────────────────────────────────────┘"
     echo ""
 }
@@ -192,17 +192,21 @@ EOF
             echo "writer,writing,none"
             ;;
         table|*)
-            echo "╔════════════════╤═══════════════╤═══════════╗"
-            echo "║ Agent          │ Role          │ Isolation ║"
-            echo "╠════════════════╪═══════════════╪═══════════╣"
-            echo "║ prod-strategist│ strategy      │ none      ║"
-            echo "║ prod-tactician │ discovery     │ none      ║"
-            echo "║ researcher     │ exploration   │ none      ║"
-            echo "║ planner        │ planning      │ none      ║"
-            echo "║ implementer    │ execution     │ worktree  ║"
-            echo "║ reviewer       │ verification  │ none      ║"
-            echo "║ designer       │ design        │ none      ║"
-            echo "╚════════════════╧═══════════════╧═══════════╝"
+            echo "╔═════════════╤══════════════╤═══════════╗"
+            echo "║ Agent       │ Role         │ Isolation ║"
+            echo "╠═════════════╪══════════════╪═══════════╣"
+            echo "║ boardroom   │ advisory     │ none      ║"
+            echo "║ designer    │ design       │ none      ║"
+            echo "║ implementer │ execution    │ worktree  ║"
+            echo "║ planner     │ planning     │ none      ║"
+            echo "║ reflector   │ reflection   │ none      ║"
+            echo "║ researcher  │ exploration  │ none      ║"
+            echo "║ reviewer    │ verification │ none      ║"
+            echo "║ skeptic     │ critique     │ none      ║"
+            echo "║ strategist  │ strategy     │ none      ║"
+            echo "║ tactician   │ discovery    │ none      ║"
+            echo "║ writer      │ writing      │ none      ║"
+            echo "╚═════════════╧══════════════╧═══════════╝"
             ;;
     esac
     return 0

--- a/scripts/claude-agents/test-agent-workflows.sh
+++ b/scripts/claude-agents/test-agent-workflows.sh
@@ -2,7 +2,9 @@
 set -e
 
 # Test Agent Workflows Script
-# Validates the 7-agent orchestration pattern (product-strategist → product-tactician → researcher → planner → implementer → reviewer → designer)
+# Validates the agent orchestration pattern (researcher → planner → implementer → reviewer)
+# Plus per-agent definition checks for the full roster (boardroom, designer, implementer,
+# planner, reflector, researcher, reviewer, skeptic, strategist, tactician, writer).
 
 source "$(dirname "$0")/../../lib/common.sh"
 
@@ -11,7 +13,7 @@ TEST_MODE="${1:-all}"
 print_banner() {
     echo ""
     echo "════════════════════════════════════════════════"
-    echo "    Agent Workflow Testing Suite (7-Agent)"
+    echo "    Agent Workflow Testing Suite"
     echo "════════════════════════════════════════════════"
     echo ""
 }
@@ -20,7 +22,7 @@ print_banner() {
 test_agent_definitions() {
     print_info "Testing Agent Definitions"
 
-    local agents=("product-strategist" "product-tactician" "researcher" "planner" "implementer" "reviewer" "designer")
+    local agents=("boardroom" "designer" "implementer" "planner" "reflector" "researcher" "reviewer" "skeptic" "strategist" "tactician" "writer")
     local failed=0
 
     for agent in "${agents[@]}"; do

--- a/scripts/setup-claude-agentic.sh
+++ b/scripts/setup-claude-agentic.sh
@@ -914,7 +914,7 @@ Project init creates:
     git repo                            (initialized if not present)
     CLAUDE.md                           project template (customize for your stack)
     README.md                           minimal skeleton (if not present)
-    .claude/agents/                     product-tactician, researcher, planner, implementer, reviewer, designer
+    .claude/agents/                     boardroom, designer, implementer, planner, reflector, researcher, reviewer, skeptic, strategist, tactician, writer
     .claude/skills/                     base skills + type-specific skills
     .claude/settings.json               type-specific hooks (merged with existing)
     .claude-agents.json                 (only if not present)

--- a/tests/integration/test_project_init.sh
+++ b/tests/integration/test_project_init.sh
@@ -32,7 +32,7 @@ assert_file_exists "$WEB_DIR/.claude-agents.json" ".claude-agents.json created"
 assert_directory_exists "$WEB_DIR/.git" "Git repo initialized"
 
 # Agents
-for agent in product-tactician researcher planner implementer reviewer designer; do
+for agent in boardroom designer implementer planner reflector researcher reviewer skeptic strategist tactician writer; do
     assert_file_exists "$WEB_DIR/.claude/agents/${agent}.md" "Agent: $agent"
 done
 


### PR DESCRIPTION
## Summary

Restores main to a consistent post-rename state after PR #125 (admin-bypassed past these issues). Originally scoped as docs-only cleanup; **expanded in round 2** to address Copilot's substantive review comments — which surfaced real runtime drift, not just prose.

## What ships

| Layer | Files | Why |
|---|---|---|
| **Runtime config** (BLOCKING) | `.claude-agents.json` | Renames `product-strategist`/`product-tactician` → `strategist`/`tactician`; adds 4 missing agents (`boardroom`, `skeptic`, `reflector`, `writer`); fixes workflow phases + outputs path; bumps version 1.0.0 → 1.1.0. New projects ship correct metadata. |
| **CI / test infrastructure** | `.github/workflows/ci.yml`, `scripts/claude-agents/test-agent-workflows.sh`, `scripts/claude-agents/agent-benchmarks.sh`, `tests/integration/test_project_init.sh` | Agent validation steps now check the 11-agent roster (was 7); benchmark output (table + JSON + CSV) reflects current agents; integration test expects new agent files |
| **Skill / setup helpers** | `scripts/setup-claude-agentic.sh` | Help-text agent list updated |
| **Docs (1-line fixes)** | `.claude/skills/init-project/SKILL.md`, `docs/architecture.md`, `docs/design/agentic-design-integration.md` | Agent count + names corrected |
| **Skill prose drift** (original scope) | `.claude/skills/decision-lab/{STAGE-PLAYBOOKS,ARTIFACTS,FRAMEWORKS,COUNCIL}.md` | "product strategist" → "strategist agent"; drop leftover "(continued in Task 2)" text |

## Out of scope (tracked separately)

- **`docs/CLAUDE_AGENTS.md`** — needs ~80 line edits + structural reorg to add sections for the 4 new agents. Tracked in [#128](https://github.com/mojwang/macbook-dev-setup/issues/128).

## Why this PR validates the new strict gates

- macbook-dev-setup ruleset's admin always-bypass was removed earlier today
- This PR is the first merge attempt under the strict gates
- All 5 required status checks must pass (test, validate-documentation, security-scan, Claude Code Review, All Checks Pass)
- Copilot review must complete with all threads resolved
- No `--admin` bypass available

If this lands cleanly under those constraints → strict gates verified end-to-end + main returns to a fully consistent post-rename state.

## Test plan

- [x] All file changes scoped to rename-completion + drift fixes
- [x] No filename or symlink changes
- [x] Round-1 CI: 5/7 checks pass; Agent Workflow Validation initially failed → fixed in commit 2 (CI workflow agent list update)
- [x] Round-1 Copilot: 6 inline comments → all addressed in round 2 (this commit) or deferred to #128 with explicit out-of-scope note
- [ ] Round-2 CI: all 5 required checks pass
- [ ] Round-2 Copilot: re-review approves OR all unresolved threads explicitly resolved with out-of-scope reasoning