### PR TITLE
chore(ci): pin claude-code-action to v1.0.112 (workaround v1.0.113 regression)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,7 +50,12 @@ jobs:
             echo "copilot_feedback=present" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: anthropics/claude-code-action@v1
+      # Pinned to v1.0.112 (2026-05-04) — v1.0.113 (released 2026-05-06)
+      # has a regression: "Internal error: directory mismatch for directory
+      # tsconfig.json" causes the action to fail at startup. Restore to @v1
+      # once Anthropic ships a fix (likely v1.0.114+).
+      # Tracking: https://github.com/anthropics/claude-code-action/issues
+      - uses: anthropics/claude-code-action@v1.0.112
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin \`anthropics/claude-code-action\` from \`@v1\` (moving tag, currently resolves to v1.0.113) to \`@v1.0.112\` (last known good). v1.0.113 was released 2026-05-06 ~3 hours ago and contains a regression that fails at startup:

\`\`\`
##[error]Action failed with error: Environment variable validation failed:
Internal error: directory mismatch for directory ".../claude-code-action/v1/tsconfig.json"
\`\`\`

Reproducible across re-runs. Affects every PR in this repo because Claude Code Review is a required status check in the PR-quality-gates ruleset.

## Why this PR exists right now

PR #108 (community parallel-brew install) is BLOCKED specifically on this — its Claude Code Review job has failed both attempts with the same internal-error stack. Pinning unblocks #108 + every other PR in flight.

## Rollback

Once Anthropic ships v1.0.114+ that fixes the regression, revert this pin back to \`@v1\`. The fix path is tracked in a code comment.

## Test plan

- [x] One-line config change; no logic
- [ ] CI passes (this PR's own Claude Code Review will validate the pinned version)