### PR TITLE
chore(ci): skip Claude Code Review on fork PRs (no secrets available)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,11 +14,18 @@ jobs:
   review:
     name: Claude Code Review
     runs-on: ubuntu-latest
-    # Skip if Claude's own review triggered this (avoid loops)
+    # Skip on:
+    #   - Fork PRs: GitHub does not pass user-defined secrets (CLAUDE_CODE_OAUTH_TOKEN)
+    #     to workflows triggered from forks. Without the token, the action fails at
+    #     env validation. Skipping returns SUCCESS for the required-status-check
+    #     ruleset, so fork PRs are still mergeable (Copilot review remains the
+    #     active automated reviewer for fork PRs).
+    #   - Self-triggered loops: pull_request_review events from anyone but Copilot.
     if: >-
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_review' &&
-       github.event.review.user.login == 'copilot-pull-request-reviewer')
+      github.event.pull_request.head.repo.fork == false &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'pull_request_review' &&
+        github.event.review.user.login == 'copilot-pull-request-reviewer'))
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

GitHub does not pass user-defined secrets to fork-PR workflows by default — security feature against secret exfiltration. Without \`CLAUDE_CODE_OAUTH_TOKEN\`, the action fails at env validation. Adds an \`if:\` condition that skips the \`review\` job on fork PRs.

## Why now

PR #108 (jdcodes1's parallel-brew installs) is BLOCKED because Claude Code Review is in the required-status-checks list and fails on every run for fork PRs. This unblocks #108 and any future community contributions.

## What changes

| | Before | After |
|---|---|---|
| Internal-branch PR | Claude review runs (had secrets) | Same — no change |
| Fork PR | Claude review fails (no secrets) → merge BLOCKED | Claude review SKIPPED → counts as PASSED for required-checks → merge unblocked |

Copilot still reviews fork PRs (separate service, no secret dependency). Other CI checks unchanged.

## Trade-off

Fork PRs lose automated Claude Code Review. Acceptable for low-volume community contributions. If volume grows, revisit with a two-stage \`workflow_run\` pattern (more complex but preserves Claude review on forks).

## Test plan

- [x] Single-line \`if:\` condition addition (no logic change for non-fork PRs)
- [ ] CI passes on this PR (own branch, will trigger Claude review normally)
- [ ] After merge: PR #108 re-runs CI → Claude Code Review shows SKIPPED → mergeable