### PR TITLE
feat(board): add [TAG] markers to advisor turns for parseable positions

### DIFF
--- a/.claude/agents/boardroom.md
+++ b/.claude/agents/boardroom.md
@@ -162,9 +162,9 @@ When channeling an advisor, draw on their `signature-moves` field. Speak as them
 - **Naval** [PRINCIPAL-VS-SALARY]: Slow down. Are you building principal or trading hours?
 - **Cagan** [RISKIEST-ASSUMPTION]: Both of you are arguing past the actual problem — there's no evidence yet.
 
-**Tagging rule**: every advisor turn ends its leading line with a single bracketed tag drawn from that advisor's `tags:` field in COUNCIL.md. Format: `**<Advisor>** [TAG]: <turn content>`. Pick the tag that best characterizes the move in that turn.
+**Tagging rule**: every advisor turn MUST start with the exact prefix `**<Advisor>** [TAG]:` (an asterisk-bolded advisor name, a single space, a bracketed tag drawn from that advisor's `tags:` field in COUNCIL.md, then a colon). The `[TAG]` sits between the advisor name and the colon — this is the regex anchor (`^\*\*[A-Z][^*]+\*\* \[[A-Z][A-Z0-9-]+\]:`) used by post-session parsers. Pick the tag that best characterizes the move in that turn.
 
-**If no existing tag fits**: propose a new one inline (e.g., `[NEW-TAG-PROPOSAL]`) with a parenthetical note like *(propose new tag for COUNCIL.md)*. Surface it in the session log so it can be added to the advisor's `tags:` field post-session.
+**If no existing tag fits**: use `[NEW-TAG-PROPOSAL]` as the tag value (preserving the prefix shape so the parser still matches), then add a parenthetical *(propose new tag — `<SUGGESTED-TAG>` — for COUNCIL.md)* AFTER the colon, in the turn's body. Never put parenthetical notes between `]` and `:` — that breaks the parser. Surface the proposal in the session log so the new tag can be added to the advisor's `tags:` field post-session.
 
 The advisor `id` (e.g. `customer-obsessed-long-arc`) still anchors metadata: frontmatter `council:` blocks, `track-record` updates, `natural-tensions:` cross-references. Use the source name in conversational prose; use the id in structured data; use the `[TAG]` to characterize each turn's move.
 

--- a/.claude/agents/boardroom.md
+++ b/.claude/agents/boardroom.md
@@ -156,13 +156,17 @@ The scoring is reasoned in natural language — no separate scoring code. Read C
 
 When channeling an advisor, draw on their `signature-moves` field. Speak as them — argue from their perspective, use their characteristic moves and vocabulary.
 
-**For internal session output (this is where you spend most of your time)**: name the source thinker freely. The boardroom is private advisory tooling — Marvin needs to recognize who's speaking to grade the session and feel the distinctive weight of each lens. Mark transitions like:
+**For internal session output (this is where you spend most of your time)**: name the source thinker freely AND tag every turn with one of the advisor's `tags:` (see COUNCIL.md). The boardroom is private advisory tooling — Marvin needs to recognize who's speaking to grade the session and feel the distinctive weight of each lens. Tags make advisor positions machine-parseable for post-session synthesis and future auto-grading. Mark transitions like:
 
-- **Bezos**: *(working backwards)* What would the press release for this say?
-- **Naval**: Slow down. Are you building principal or trading hours?
-- **Cagan**: Both of you are arguing past the actual problem — there's no evidence yet.
+- **Bezos** [PRESS-RELEASE-FIRST]: What would the press release for this say?
+- **Naval** [PRINCIPAL-VS-SALARY]: Slow down. Are you building principal or trading hours?
+- **Cagan** [RISKIEST-ASSUMPTION]: Both of you are arguing past the actual problem — there's no evidence yet.
 
-The advisor `id` (e.g. `customer-obsessed-long-arc`) still anchors metadata: frontmatter `council:` blocks, `track-record` updates, `natural-tensions:` cross-references. Use the source name in conversational prose; use the id in structured data.
+**Tagging rule**: every advisor turn ends its leading line with a single bracketed tag drawn from that advisor's `tags:` field in COUNCIL.md. Format: `**<Advisor>** [TAG]: <turn content>`. Pick the tag that best characterizes the move in that turn.
+
+**If no existing tag fits**: propose a new one inline (e.g., `[NEW-TAG-PROPOSAL]`) with a parenthetical note like *(propose new tag for COUNCIL.md)*. Surface it in the session log so it can be added to the advisor's `tags:` field post-session.
+
+The advisor `id` (e.g. `customer-obsessed-long-arc`) still anchors metadata: frontmatter `council:` blocks, `track-record` updates, `natural-tensions:` cross-references. Use the source name in conversational prose; use the id in structured data; use the `[TAG]` to characterize each turn's move.
 
 **The no-brand-attribution rule still binds when:**
 - A session insight is graduated to a vault note (synthesis becomes Marvin's voice)

--- a/.claude/skills/board-of-advisors/SKILL.md
+++ b/.claude/skills/board-of-advisors/SKILL.md
@@ -43,7 +43,7 @@ After approval, open Round 1: each advisor asks ONE pointed question to the CEO.
 The dialogue IS the session. The orchestrator does not dispatch a subagent for this phase — it would break the closed feedback loop.
 
 **Phase 3 — Synthesis + persistence (orchestrator)**:
-When dialogue concludes, write the session log to `decision-lab/board-of-advisors/YYYY-MM-DD-<slug>-<mode>.md` per the schema in `decision-lab/board-of-advisors/README.md`. Capture the full dialogue transcript with **Bezos** / **Naval** / **Cagan** turn markers + **You** for CEO turns. Then synthesize, recommend, and offer optional grading + commit.
+When dialogue concludes, write the session log to `decision-lab/board-of-advisors/YYYY-MM-DD-<slug>-<mode>.md` per the schema in `decision-lab/board-of-advisors/README.md`. Capture the full dialogue transcript with `**<Advisor>** [TAG]:` turn markers (per § Voice Synthesis tagging rule in `boardroom.md`) + `**You**:` for CEO turns. Then synthesize, recommend, and offer optional grading + commit.
 
 ## Notes
 

--- a/.claude/skills/decision-lab/COUNCIL.md
+++ b/.claude/skills/decision-lab/COUNCIL.md
@@ -314,6 +314,24 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - '"Are you playing for principal or salary?" — equity in the work, not just income from it'
     - '"Asymmetric upside" — small downside, uncapped upside; the only bets worth making'
 
+  tags: [AMP-IT-UP, DATE-DEMAND, DROP-DIPLOMATIC]
+
+  tags: [PRESS-RELEASE-FIRST, TYPE-1-VS-TYPE-2, DAY-1-CHECK, DATA-AND-ANECDOTE]
+
+  tags: [KEEPER-TEST, STUNNING-COLLEAGUES, CONTEXT-NOT-CONTROL, INFORMED-CAPTAIN]
+
+  tags: [RETURN-ON-INCREMENTAL, ALTERNATIVE-USE, DISTRIBUTE-OR-REINVEST]
+
+  tags: [BORING-PROFITABLE-DURABLE, 30-YEAR-HOLD, MAIN-STREET, OWNER-DEPENDENCY]
+
+  tags: [INVERSION, INCENTIVES, AVOID-STUPIDITY, SECOND-ORDER]
+
+  tags: [WHICH-OF-7-POWERS, BENEFIT-PLUS-BARRIER, IF-COPIED-WHAT-CHANGES]
+
+  tags: [OUTCOMES-OVER-OUTPUT, DISCOVERY-VS-DELIVERY, RISKIEST-ASSUMPTION]
+
+  tags: [LEVERAGE-CHECK, PRINCIPAL-VS-SALARY, SPECIFIC-KNOWLEDGE, ASYMMETRIC-UPSIDE]
+
   natural-tensions:
     - vs mental-models: asymmetric upside leverage vs avoid-stupidity downside protection
     - vs operator-execution: leverage-first thinking vs execution-intensity-first thinking

--- a/.claude/skills/decision-lab/COUNCIL.md
+++ b/.claude/skills/decision-lab/COUNCIL.md
@@ -34,6 +34,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - '"Drive, alignment, execution" — narrow focus beats broad initiatives'
     - Cuts through consensus-by-politeness; surfaces what people actually think
 
+  tags: [AMP-IT-UP, DATE-DEMAND, DROP-DIPLOMATIC]
+
   natural-tensions:
     - vs customer-obsessed-long-arc: intensity-now vs patient long-arc
     - vs talent-density-context-not-control: top-down standards vs distributed judgment
@@ -68,6 +70,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - '"Disagree and commit" — disagreement is fine; lingering disagreement after the call is not'
     - '"Day 1 vs Day 2" — surfaces process-for-process-sake, proxy metrics, customer-orientation as theater'
     - Narrative memos over slides; if you can't write it in prose, you don't understand it
+
+  tags: [PRESS-RELEASE-FIRST, TYPE-1-VS-TYPE-2, DAY-1-CHECK, DATA-AND-ANECDOTE]
 
   natural-tensions:
     - vs operator-execution: long-arc patience vs intensity-now
@@ -104,6 +108,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - '"Informed captain" replaces approval gates — one decision-maker, broad input'
     - '"No rules rules" — eliminate process; trust judgment; document principles, not procedures'
 
+  tags: [KEEPER-TEST, STUNNING-COLLEAGUES, CONTEXT-NOT-CONTROL, INFORMED-CAPTAIN]
+
   natural-tensions:
     - vs operator-execution: distributed judgment vs top-down standards
     - vs acquisition-long-hold: fire fast vs long-hold relationships
@@ -138,6 +144,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - Skeptical of empire-building, M&A theater, and "strategic" investments without ROI logic
     - '"Return on incremental capital" beats absolute returns'
     - Distribution beats reinvestment when reinvestment opportunities are weak
+
+  tags: [RETURN-ON-INCREMENTAL, ALTERNATIVE-USE, DISTRIBUTE-OR-REINVEST]
 
   natural-tensions:
     - vs product-empowered-orgs: build product-led vs sometimes don't build, allocate capital instead
@@ -174,6 +182,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - '"Main street, not Sand Hill" — small businesses with real cash flow over venture-shaped bets'
     - Surfaces relationship moats operators dismiss because they don't scale to billion-dollar TAM
 
+  tags: [BORING-PROFITABLE-DURABLE, 30-YEAR-HOLD, MAIN-STREET, OWNER-DEPENDENCY]
+
   natural-tensions:
     - vs talent-density-context-not-control: long-hold relationships vs fire-fast standards
     - vs operator-execution: patient compounding vs amp-it-up intensity
@@ -208,6 +218,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - Pulls models from psychology, economics, engineering, biology — refuses single-discipline analysis
     - 'Names the cognitive biases at play: social proof, commitment bias, availability heuristic'
     - '"I never want to be there" — surfaces second-order and third-order effects others miss'
+
+  tags: [INVERSION, INCENTIVES, AVOID-STUPIDITY, SECOND-ORDER]
 
   natural-tensions:
     - vs leverage-and-judgment: avoid stupidity downside vs asymmetric upside leverage
@@ -244,6 +256,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - Distinguishes power (structural) from advantage (transient) from preference (taste)
     - 'Pressure-tests durability under stress: founder leaves, market shifts, capital floods in'
 
+  tags: [WHICH-OF-7-POWERS, BENEFIT-PLUS-BARRIER, IF-COPIED-WHAT-CHANGES]
+
   natural-tensions:
     - vs operator-execution: structural moat vs operational excellence
     - vs acquisition-long-hold: explicit power-source vs relationship-moat (Helmer would press to formalize)
@@ -279,6 +293,8 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - Demands product judgment, not roadmap stenography
     - '"Customer-facing problems they own" — empowerment requires owning the problem space, not just the implementation'
 
+  tags: [OUTCOMES-OVER-OUTPUT, DISCOVERY-VS-DELIVERY, RISKIEST-ASSUMPTION]
+
   natural-tensions:
     - vs capital-allocator: build product-led vs sometimes don't build
     - vs strategy-power: org-design as competitive advantage vs structural-power as the real moat
@@ -313,22 +329,6 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
     - '"Play long-term games with long-term people" — iterated reputation is the actual asset'
     - '"Are you playing for principal or salary?" — equity in the work, not just income from it'
     - '"Asymmetric upside" — small downside, uncapped upside; the only bets worth making'
-
-  tags: [AMP-IT-UP, DATE-DEMAND, DROP-DIPLOMATIC]
-
-  tags: [PRESS-RELEASE-FIRST, TYPE-1-VS-TYPE-2, DAY-1-CHECK, DATA-AND-ANECDOTE]
-
-  tags: [KEEPER-TEST, STUNNING-COLLEAGUES, CONTEXT-NOT-CONTROL, INFORMED-CAPTAIN]
-
-  tags: [RETURN-ON-INCREMENTAL, ALTERNATIVE-USE, DISTRIBUTE-OR-REINVEST]
-
-  tags: [BORING-PROFITABLE-DURABLE, 30-YEAR-HOLD, MAIN-STREET, OWNER-DEPENDENCY]
-
-  tags: [INVERSION, INCENTIVES, AVOID-STUPIDITY, SECOND-ORDER]
-
-  tags: [WHICH-OF-7-POWERS, BENEFIT-PLUS-BARRIER, IF-COPIED-WHAT-CHANGES]
-
-  tags: [OUTCOMES-OVER-OUTPUT, DISCOVERY-VS-DELIVERY, RISKIEST-ASSUMPTION]
 
   tags: [LEVERAGE-CHECK, PRINCIPAL-VS-SALARY, SPECIFIC-KNOWLEDGE, ASYMMETRIC-UPSIDE]
 

--- a/.claude/skills/decision-lab/board-of-advisors/README.md
+++ b/.claude/skills/decision-lab/board-of-advisors/README.md
@@ -45,10 +45,10 @@ grades:
 ## Session
 
 ### Turn 1
-**<advisor-id>**: ...
+**<Advisor>** [TAG]: ...
 
 ### Turn 2
-**<advisor-id>**: ...
+**<Advisor>** [TAG]: ...
 
 ...
 
@@ -61,15 +61,17 @@ grades:
 
 ## Voice attribution rule
 
-Within session logs and live boardroom output, advisors are introduced by their **source thinker name** (e.g. **Bezos**, **Naval**, **Cagan**) as the conversational marker — it's how Marvin recognizes who's speaking and grades the session. The advisor `id` still anchors structured metadata: frontmatter `council:` block, `track-record:` updates in COUNCIL.md, `natural-tensions:` cross-references.
+Within session logs and live boardroom output, advisors are introduced by their **source thinker name** (e.g. **Bezos**, **Naval**, **Cagan**) AND a bracketed `[TAG]` from the advisor's `tags:` field in COUNCIL.md. The exact prefix shape `**<Advisor>** [TAG]:` is the regex anchor that post-session parsers and any future auto-grading rely on. The advisor `id` still anchors structured metadata: frontmatter `council:` block, `track-record:` updates in COUNCIL.md, `natural-tensions:` cross-references.
 
 ```markdown
 ### Turn 1
-**Bezos**: Write the press release. Headline, sub-head, customer quote. Who is the customer in that quote?
+**Bezos** [PRESS-RELEASE-FIRST]: Write the press release. Headline, sub-head, customer quote. Who is the customer in that quote?
 
 ### Turn 2
-**Naval**: Slow down. The press-release frame assumes you already know the product...
+**Naval** [PRINCIPAL-VS-SALARY]: Slow down. The press-release frame assumes you already know the product...
 ```
+
+See `.claude/agents/boardroom.md` § Voice Synthesis for the full tagging rule, including how to propose new tags inline when no existing tag fits.
 
 The no-brand-attribution rule still binds when session insights are graduated to vault notes or published externally. At that point the synthesis becomes Marvin's voice — the boardroom output is the working draft, not the final artifact.
 


### PR DESCRIPTION
## Summary

Adds machine-parseable tags to /boardroom dialogue. Every advisor turn now ends its leading line with a bracketed tag drawn from the advisor's tag enumeration:

\`\`\`markdown
**Naval** [LEVERAGE-CHECK]: Joy is dividend, not principal...
**Munger** [INVERSION]: You're describing the failure mode...
**Slootman** [DATE-DEMAND]: Pick July or October...
\`\`\`

## Why

Without machine-parseable advisor positions, every future analysis pass is heuristic. With tags, post-session synthesis and any future auto-grading become deterministic regex-extractable. Foundational change — every subsequent /boardroom improvement assumes this is in place.

## What changed

| File | Change |
|---|---|
| \`.claude/skills/decision-lab/COUNCIL.md\` | \`tags:\` field added to all 9 sitting advisors (3-5 tags each, derived from existing signature-moves) |
| \`.claude/agents/boardroom.md\` § Voice Synthesis | Tagging rule + format example; fallback for proposing new tags inline when no existing tag fits |

## What's NOT in this PR

Per v5 plan, four other improvements considered but deferred with explicit causal triggers:
- B. Separate Chairman synthesizer voice — defer until next session shows verdict still buried in narrative
- C. Auto-graded advisor contribution — defer until A + 3 sessions accumulated
- D. Per-session cost transparency — defer until Marvin asks
- E. Multi-model dispatch in \`--live\` — deferred per Marvin

## Verification

After merge, the next /boardroom session must produce 100% taggable turns. Test:

\`\`\`bash
# Each advisor turn line should match this pattern:
grep -E '^\\*\\*[A-Z][^*]+\\*\\* \\[[A-Z][A-Z0-9-]+\\]:' decision-lab/board-of-advisors/<latest>.md | wc -l
# Compare to total advisor turns:
grep -cE '^\\*\\*[A-Z][^*]+\\*\\*:' decision-lab/board-of-advisors/<latest>.md
# These two counts must be equal.
\`\`\`

## Plan lineage

Plan iterated v1 → v5 with adversarial pass at v4. Approved scope: ship A only, defer everything else. Plan archived at \`~/.claude/plans/can-the-entire-vault-elegant-island.md\`.