### PR TITLE
feat(theme): coordinate Catppuccin Mocha across stack

### DIFF
--- a/dotfiles/.config/nvim/init.lua
+++ b/dotfiles/.config/nvim/init.lua
@@ -1,6 +1,20 @@
 -- Basic Neovim configuration
 -- This configuration provides essential settings for a modern development environment
 
+-- Plugins via vim.pack (built-in package manager, nvim 0.12+). Guarded so
+-- older nvim versions still load the rest of the config without erroring.
+if vim.pack and vim.pack.add then
+  vim.pack.add({
+    { src = "https://github.com/catppuccin/nvim", name = "catppuccin" },
+  })
+  -- Configure flavor BEFORE applying the colorscheme. Mocha matches the
+  -- Warp + tmux + bat palette ("Catppuccin Mocha" everywhere).
+  pcall(function()
+    require("catppuccin").setup({ flavour = "mocha", transparent_background = false })
+  end)
+  pcall(vim.cmd.colorscheme, "catppuccin-mocha")
+end
+
 -- Basic settings
 vim.opt.number = true              -- Show line numbers
 vim.opt.relativenumber = true      -- Show relative line numbers

--- a/dotfiles/.config/tmux/tmux.conf
+++ b/dotfiles/.config/tmux/tmux.conf
@@ -64,10 +64,10 @@ bind -r L resize-pane -R 5
 
 # ──────────────────────────── status ────────────────────────────
 set -g status-position top
-set -g status-style "bg=default fg=default"
-set -g status-left  "#[bold]  #S #[nobold]│ "
-set -g status-right "%a %b %d  %H:%M  #h"
-set -g status-left-length 30
+# Status content is owned by catppuccin/tmux below. Length set high enough so
+# the rendered status modules don't get truncated on narrow windows.
+set -g status-left-length  100
+set -g status-right-length 100
 
 # ───────────────────────── plugins (TPM) ────────────────────────
 set -g @plugin 'tmux-plugins/tpm'
@@ -75,6 +75,17 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
+
+# Catppuccin Mocha — coordinated with Warp + nvim + bat
+set -g @plugin 'catppuccin/tmux#v2.1.3'
+set -g @catppuccin_flavor 'mocha'
+set -g @catppuccin_window_status_style 'rounded'
+set -g @catppuccin_window_text ' #W'
+set -g @catppuccin_window_current_text ' #W'
+# Compose status: session on left, application + date/time + host on right
+set -g status-left  '#{E:@catppuccin_status_session}'
+set -g status-right '#{E:@catppuccin_status_application}#{E:@catppuccin_status_date_time}#{E:@catppuccin_status_host}'
+set -g @catppuccin_date_time_text "%a %b %d  %H:%M"
 
 set -g @continuum-restore 'on'    # auto-restore last session on tmux start
 

--- a/dotfiles/.config/zsh/20-tools.zsh
+++ b/dotfiles/.config/zsh/20-tools.zsh
@@ -36,13 +36,20 @@ fi
 # Enhanced cat (bat)
 if command -v bat &> /dev/null; then
     alias cat="bat"
-    export BAT_THEME="auto"
+    # Catppuccin Mocha — coordinated with Warp/tmux/nvim. The four Catppuccin
+    # variants ship with bat; "Catppuccin Mocha" must match the theme name
+    # as listed by `bat --list-themes`.
+    export BAT_THEME="Catppuccin Mocha"
 fi
 
-# Fuzzy finder (fzf)
+# Fuzzy finder (fzf) — Catppuccin Mocha palette overrides
 if command -v fzf &> /dev/null; then
     eval "$(fzf --zsh)"
-    export FZF_DEFAULT_OPTS="--height 40% --layout=reverse --border"
+    export FZF_DEFAULT_OPTS="--height 40% --layout=reverse --border \
+--color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 \
+--color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc \
+--color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8 \
+--color=selected-bg:#45475a --color=border:#313244,label:#cdd6f4"
     
     # Use fd for fzf if available
     if command -v fd &> /dev/null; then

--- a/dotfiles/.warp/themes/catppuccin_mocha.yml
+++ b/dotfiles/.warp/themes/catppuccin_mocha.yml
@@ -1,0 +1,23 @@
+background: '#1e1e2e'
+accent: '#f5e0dc'
+foreground: '#cdd6f4'
+details: darker
+terminal_colors:
+  normal:
+    black: '#45475a'
+    red: '#f38ba8'
+    green: '#a6e3a1'
+    yellow: '#f9e2af'
+    blue: '#89b4fa'
+    magenta: '#f5c2e7'
+    cyan: '#94e2d5'
+    white: '#bac2de'
+  bright:
+    black: '#585b70'
+    red: '#f38ba8'
+    green: '#a6e3a1'
+    yellow: '#f9e2af'
+    blue: '#89b4fa'
+    magenta: '#f5c2e7'
+    cyan: '#94e2d5'
+    white: '#a6adc8'

--- a/scripts/setup-dotfiles.sh
+++ b/scripts/setup-dotfiles.sh
@@ -36,6 +36,7 @@ backup_organized ~/.config/nvim "dotfiles" "Neovim config backup"
 backup_organized ~/.config/zsh "dotfiles" "Zsh config backup"
 backup_organized ~/.config/starship.toml "dotfiles" "Starship config backup"
 backup_organized ~/.config/tmux/tmux.conf "dotfiles" "tmux config backup"
+backup_organized ~/.warp/settings.toml "dotfiles" "Warp settings backup"
 
 # Install dotfiles
 install_dotfile() {
@@ -169,6 +170,32 @@ install_dotfile "dotfiles/.config/starship.toml" ~/.config/starship.toml "Starsh
 if [[ -f "dotfiles/.config/tmux/tmux.conf" ]]; then
     mkdir -p ~/.config/tmux
     install_dotfile "dotfiles/.config/tmux/tmux.conf" ~/.config/tmux/tmux.conf "tmux configuration"
+fi
+
+# Setup Warp custom themes (~/.warp/themes/) and flip the active theme.
+# Warp themes don't follow XDG; they live under ~/.warp/. We deploy YAMLs and
+# point Warp at catppuccin_mocha by patching only the theme= line in
+# settings.toml, leaving everything else (font, agent prefs, etc.) untouched.
+if [[ -d "dotfiles/.warp/themes" && -d "$HOME/.warp" ]]; then
+    mkdir -p "$HOME/.warp/themes"
+    for theme_file in dotfiles/.warp/themes/*.yml; do
+        [[ -f "$theme_file" ]] || continue
+        cp "$theme_file" "$HOME/.warp/themes/"
+        print_success "Deployed Warp theme: $(basename "$theme_file")"
+    done
+
+    settings="$HOME/.warp/settings.toml"
+    if [[ -f "$settings" ]] && ! grep -q 'theme = "catppuccin_mocha"' "$settings"; then
+        backup_file "$settings" "warp-settings"
+        # Flip ONLY the [appearance.themes].theme = "..." line. sed -i '' is
+        # macOS-safe; the regex anchors on whitespace + theme= to avoid
+        # matching the system_theme key.
+        if sed -i '' 's/^[[:space:]]*theme[[:space:]]*=[[:space:]]*".*"/theme = "catppuccin_mocha"/' "$settings"; then
+            print_success "Warp active theme switched to catppuccin_mocha"
+        else
+            print_warning "Could not patch Warp theme in $settings — set manually via Settings → Appearance"
+        fi
+    fi
 fi
 
 # Create scripts directory and copy scripts

--- a/tests/unit/test_theme_catppuccin.sh
+++ b/tests/unit/test_theme_catppuccin.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Tests for the Catppuccin Mocha coordinated theme across Warp / tmux / nvim
+# / bat / fzf. Asserts on the repo source-of-truth files and (when the live
+# tool is present) verifies the deployed config picks the correct palette.
+
+source "$(dirname "$0")/../test_framework.sh"
+
+if [[ -f "$ROOT_DIR/lib/common.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/lib/common.sh"
+fi
+
+describe "Catppuccin Mocha Coordinated Theme"
+
+WARP_THEME="$ROOT_DIR/dotfiles/.warp/themes/catppuccin_mocha.yml"
+TMUX_CONF="$ROOT_DIR/dotfiles/.config/tmux/tmux.conf"
+NVIM_INIT="$ROOT_DIR/dotfiles/.config/nvim/init.lua"
+ZSH_TOOLS="$ROOT_DIR/dotfiles/.config/zsh/20-tools.zsh"
+DOTFILES_SETUP="$ROOT_DIR/scripts/setup-dotfiles.sh"
+
+# ─── Warp theme ─────────────────────────────────────────────────────
+it "should ship Warp catppuccin_mocha theme YAML"
+assert_file_exists "$WARP_THEME" "Warp Catppuccin Mocha YAML should exist"
+assert_file_contains "$WARP_THEME" "background: '#1e1e2e'" "background should be Mocha base"
+assert_file_contains "$WARP_THEME" "foreground: '#cdd6f4'" "foreground should be Mocha text"
+
+it "should deploy Warp themes + flip active theme via setup-dotfiles.sh"
+assert_file_contains "$DOTFILES_SETUP" 'dotfiles/.warp/themes' "setup-dotfiles.sh should reference Warp themes source"
+assert_file_contains "$DOTFILES_SETUP" 'theme = "catppuccin_mocha"' "setup-dotfiles.sh should set the active theme"
+
+# ─── tmux ────────────────────────────────────────────────────────────
+it "should declare catppuccin/tmux plugin and Mocha flavor"
+assert_file_contains "$TMUX_CONF" "@plugin 'catppuccin/tmux" "catppuccin/tmux plugin should be declared"
+assert_file_contains "$TMUX_CONF" "@catppuccin_flavor 'mocha'" "tmux flavor should be mocha"
+assert_file_contains "$TMUX_CONF" "@catppuccin_status_session" "status-left should embed catppuccin session module"
+
+# ─── nvim ────────────────────────────────────────────────────────────
+it "should install catppuccin via vim.pack and apply mocha"
+assert_file_contains "$NVIM_INIT" "vim.pack.add" "init.lua should use vim.pack.add"
+assert_file_contains "$NVIM_INIT" "https://github.com/catppuccin/nvim" "init.lua should reference catppuccin/nvim"
+assert_file_contains "$NVIM_INIT" 'flavour = "mocha"' "catppuccin.setup should pick mocha flavour"
+assert_file_contains "$NVIM_INIT" 'colorscheme, "catppuccin-mocha"' "should set catppuccin-mocha colorscheme"
+
+it "should apply catppuccin-mocha when nvim loads"
+if command -v nvim >/dev/null 2>&1 && find "$HOME/.local/share/nvim/site/pack" -maxdepth 4 -type d -name "catppuccin*" 2>/dev/null | grep -q .; then
+    # Prefix-tag the report so we can grep past init.lua's load-success print()
+    scheme=$(nvim --headless -c 'lua print("CSCHEME:" .. tostring(vim.g.colors_name))' -c 'qa!' 2>&1 | grep -E '^CSCHEME:' | head -1)
+    assert_contains "$scheme" "catppuccin-mocha" "live nvim should report catppuccin-mocha colorscheme"
+else
+    echo "  (catppuccin not yet installed via vim.pack — skipping live colorscheme check)"
+fi
+
+# ─── bat + fzf ───────────────────────────────────────────────────────
+it "should set BAT_THEME to Catppuccin Mocha"
+assert_file_contains "$ZSH_TOOLS" 'BAT_THEME="Catppuccin Mocha"' "bat theme should be Catppuccin Mocha"
+
+it "should override FZF_DEFAULT_OPTS with the Mocha palette"
+assert_file_contains "$ZSH_TOOLS" "bg:#1e1e2e" "fzf bg should be Mocha base"
+assert_file_contains "$ZSH_TOOLS" "fg:#cdd6f4" "fzf fg should be Mocha text"
+assert_file_contains "$ZSH_TOOLS" "hl:#f38ba8" "fzf highlight should be Mocha red/pink"
+
+it "should expose the bat theme name when bat is installed"
+if command -v bat >/dev/null 2>&1; then
+    bat_themes=$(bat --list-themes 2>/dev/null | grep -F "Catppuccin Mocha" || true)
+    assert_not_empty "$bat_themes" "bat should know the Catppuccin Mocha theme"
+else
+    echo "  (bat not installed — skipping live theme check)"
+fi
+
+summarize


### PR DESCRIPTION
## Summary

Picks Catppuccin Mocha as the canonical palette and aligns every visible layer to it. Stacked on **#135** because it touches `tmux.conf` and `init.lua` from that PR.

| Layer | Change |
|---|---|
| **Warp** | New `dotfiles/.warp/themes/catppuccin_mocha.yml`. `setup-dotfiles.sh` deploys it and `sed`-patches the `[appearance.themes].theme = "..."` line in `~/.warp/settings.toml`. Everything else (font, agent prefs, vertical-tabs, etc.) is left alone. |
| **tmux** | `catppuccin/tmux@v2.1.3` via TPM. Hand-rolled status line replaced with the plugin's session/application/date-time/host modules. |
| **nvim** | `vim.pack.add{ catppuccin/nvim }` — uses 0.12's built-in package manager so no plugin manager is introduced. Colorscheme `catppuccin-mocha` with `flavour = "mocha"`. Guarded with `if vim.pack and vim.pack.add` so older nvim versions still load the rest of `init.lua`. |
| **bat** | `BAT_THEME="Catppuccin Mocha"` in `20-tools.zsh`. The four Catppuccin variants are already bundled with bat — no theme file install needed. |
| **fzf** | `FZF_DEFAULT_OPTS` extended with the Mocha palette overrides (bg #1e1e2e, fg #cdd6f4, hl #f38ba8, …). |

## Why Catppuccin Mocha?

Broadest tooling coverage in 2026 — official ports for Warp, tmux, nvim, bat, fzf, delta, starship, eza, and ~150 other tools. Mocha is the dark variant; the four flavors (Latte/Frappe/Macchiato/Mocha) are interchangeable later by flipping one var per tool.

## Out of scope (deliberate)

- **delta**, **starship**, **eza**/`LS_COLORS` — also have Catppuccin ports; left as a follow-up PR if Marvin wants the full sweep. Keeping this PR scoped to the highest-traffic tools.
- **Other nvim plugins** — only the colorscheme. No LSP, no telescope, etc. (`vim.pack` is the door, not the room.)

## Test plan

- [x] `tests/unit/test_theme_catppuccin.sh` — 18 assertions: Warp YAML palette, `setup-dotfiles.sh` wiring, tmux plugin + flavor, nvim `vim.pack` + colorscheme, BAT_THEME, FZF Mocha hex codes
- [x] Live nvim load — `vim.g.colors_name == "catppuccin-mocha"`, `Normal` bg = `#1E1E2E` (Mocha base, hex matches Warp YAML)
- [x] Live tmux — catppuccin/tmux installed via TPM bootstrap; `@catppuccin_flavor` = `mocha`; status modules present in `status-left/right`
- [x] `bat --list-themes` — "Catppuccin Mocha" available
- [x] `./tests/run_tests.sh unit` — full suite passes
- [x] `shellcheck --severity=warning` — clean on touched scripts
- [ ] Visual smoke after Warp restart — terminal bg flips to Mocha base, tmux status bar renders Mocha colors, `bat README.md` highlights in Mocha syntax

## Migration note

Switching the active Warp theme mid-session may or may not redraw immediately depending on Warp's reload behavior; a Warp restart guarantees it. The previous theme (`cyber_wave`) is preserved as a Warp built-in — switching back is one click in Settings → Appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)