### PR TITLE
feat(theme): swap Catppuccin Mocha → Solarized Dark across stack

### DIFF
--- a/dotfiles/.config/nvim/init.lua
+++ b/dotfiles/.config/nvim/init.lua
@@ -5,14 +5,16 @@
 -- older nvim versions still load the rest of the config without erroring.
 if vim.pack and vim.pack.add then
   vim.pack.add({
-    { src = "https://github.com/catppuccin/nvim", name = "catppuccin" },
+    { src = "https://github.com/maxmx03/solarized.nvim", name = "solarized.nvim" },
   })
-  -- Configure flavor BEFORE applying the colorscheme. Mocha matches the
-  -- Warp + tmux + bat palette ("Catppuccin Mocha" everywhere).
+  -- Set background BEFORE colorscheme — solarized.nvim picks the dark/light
+  -- variant from vim.o.background. "dark" matches the Warp + tmux + bat
+  -- palette ("Solarized Dark" / "Solarized (dark)" everywhere).
+  vim.o.background = "dark"
   pcall(function()
-    require("catppuccin").setup({ flavour = "mocha", transparent_background = false })
+    require("solarized").setup({ transparent = { enabled = false } })
   end)
-  pcall(vim.cmd.colorscheme, "catppuccin-mocha")
+  pcall(vim.cmd.colorscheme, "solarized")
 end
 
 -- Basic settings

--- a/dotfiles/.config/tmux/tmux.conf
+++ b/dotfiles/.config/tmux/tmux.conf
@@ -74,10 +74,25 @@ bind -r L resize-pane -R 5
 
 # ──────────────────────────── status ────────────────────────────
 set -g status-position top
-# Status content is owned by catppuccin/tmux below. Length set high enough so
-# the rendered status modules don't get truncated on narrow windows.
 set -g status-left-length  100
 set -g status-right-length 100
+
+# Solarized Dark — coordinated with Warp + nvim + bat. Hand-rolled (no
+# canonical Solarized tmux plugin equivalent to catppuccin/tmux). Palette:
+#   base03  #002b36  background (darkest)
+#   base02  #073642  background highlights / status bar
+#   base01  #586e75  comments / secondary content
+#   base0   #839496  body text
+#   yellow  #b58900  current-window highlight
+#   blue    #268bd2  session + host accent
+set -g status-style          'bg=#073642,fg=#839496'
+set -g status-left           '#[fg=#002b36,bg=#268bd2,bold] #S #[fg=#268bd2,bg=#073642,nobold] '
+set -g status-right          '#[fg=#586e75,bg=#073642] %a %b %d  %H:%M  #[fg=#268bd2,bg=#073642]#[fg=#002b36,bg=#268bd2,bold] #h '
+setw -g window-status-format         ' #I:#W '
+setw -g window-status-current-format '#[fg=#073642,bg=#b58900]#[fg=#002b36,bg=#b58900,bold] #I:#W #[fg=#b58900,bg=#073642,nobold]'
+set -g pane-border-style        'fg=#073642'
+set -g pane-active-border-style 'fg=#268bd2'
+set -g message-style            'bg=#b58900,fg=#002b36'
 
 # ───────────────────────── plugins (TPM) ────────────────────────
 set -g @plugin 'tmux-plugins/tpm'
@@ -85,17 +100,6 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
-
-# Catppuccin Mocha — coordinated with Warp + nvim + bat
-set -g @plugin 'catppuccin/tmux#v2.1.3'
-set -g @catppuccin_flavor 'mocha'
-set -g @catppuccin_window_status_style 'rounded'
-set -g @catppuccin_window_text ' #W'
-set -g @catppuccin_window_current_text ' #W'
-# Compose status: session on left, application + date/time + host on right
-set -g status-left  '#{E:@catppuccin_status_session}'
-set -g status-right '#{E:@catppuccin_status_application}#{E:@catppuccin_status_date_time}#{E:@catppuccin_status_host}'
-set -g @catppuccin_date_time_text "%a %b %d  %H:%M"
 
 set -g @continuum-restore 'on'    # auto-restore last session on tmux start
 

--- a/dotfiles/.config/zsh/20-tools.zsh
+++ b/dotfiles/.config/zsh/20-tools.zsh
@@ -36,20 +36,20 @@ fi
 # Enhanced cat (bat)
 if command -v bat &> /dev/null; then
     alias cat="bat"
-    # Catppuccin Mocha — coordinated with Warp/tmux/nvim. The four Catppuccin
-    # variants ship with bat; "Catppuccin Mocha" must match the theme name
+    # Solarized (dark) — coordinated with Warp/tmux/nvim. Both Solarized
+    # variants ship with bat; "Solarized (dark)" must match the theme name
     # as listed by `bat --list-themes`.
-    export BAT_THEME="Catppuccin Mocha"
+    export BAT_THEME="Solarized (dark)"
 fi
 
-# Fuzzy finder (fzf) — Catppuccin Mocha palette overrides
+# Fuzzy finder (fzf) — Solarized Dark palette overrides
 if command -v fzf &> /dev/null; then
     eval "$(fzf --zsh)"
     export FZF_DEFAULT_OPTS="--height 40% --layout=reverse --border \
---color=bg+:#313244,bg:#1e1e2e,spinner:#f5e0dc,hl:#f38ba8 \
---color=fg:#cdd6f4,header:#f38ba8,info:#cba6f7,pointer:#f5e0dc \
---color=marker:#b4befe,fg+:#cdd6f4,prompt:#cba6f7,hl+:#f38ba8 \
---color=selected-bg:#45475a --color=border:#313244,label:#cdd6f4"
+--color=bg+:#073642,bg:#002b36,spinner:#cb4b16,hl:#b58900 \
+--color=fg:#839496,header:#dc322f,info:#6c71c4,pointer:#268bd2 \
+--color=marker:#2aa198,fg+:#93a1a1,prompt:#268bd2,hl+:#cb4b16 \
+--color=selected-bg:#073642 --color=border:#586e75,label:#839496"
     
     # Use fd for fzf if available
     if command -v fd &> /dev/null; then

--- a/dotfiles/.warp/themes/solarized_dark.yml
+++ b/dotfiles/.warp/themes/solarized_dark.yml
@@ -1,0 +1,24 @@
+name: 'Solarized Dark'
+background: '#002b36'
+accent: '#268bd2'
+foreground: '#839496'
+details: darker
+terminal_colors:
+  normal:
+    black: '#073642'
+    red: '#dc322f'
+    green: '#859900'
+    yellow: '#b58900'
+    blue: '#268bd2'
+    magenta: '#d33682'
+    cyan: '#2aa198'
+    white: '#eee8d5'
+  bright:
+    black: '#002b36'
+    red: '#cb4b16'
+    green: '#586e75'
+    yellow: '#657b83'
+    blue: '#839496'
+    magenta: '#6c71c4'
+    cyan: '#93a1a1'
+    white: '#fdf6e3'

--- a/tests/unit/test_theme_catppuccin.sh
+++ b/tests/unit/test_theme_catppuccin.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-# Tests for the Catppuccin Mocha coordinated theme across Warp / tmux / nvim
-# / bat / fzf. Asserts on the repo source-of-truth files and (when the live
-# tool is present) verifies the deployed config picks the correct palette.
+# Catppuccin Mocha is no longer the active theme — Solarized Dark replaced
+# it across nvim/tmux/bat/fzf (see test_theme_solarized.sh). The Mocha YAML
+# is intentionally preserved in dotfiles/.warp/themes/ as a one-click Warp
+# fallback (Settings → Appearance → Themes), so this test guards that the
+# fallback YAML stays well-formed and palette-correct.
 
 source "$(dirname "$0")/../test_framework.sh"
 
@@ -11,62 +13,14 @@ if [[ -f "$ROOT_DIR/lib/common.sh" ]]; then
     source "$ROOT_DIR/lib/common.sh"
 fi
 
-describe "Catppuccin Mocha Coordinated Theme"
+describe "Catppuccin Mocha Warp Theme (Fallback)"
 
 WARP_THEME="$ROOT_DIR/dotfiles/.warp/themes/catppuccin_mocha.yml"
-TMUX_CONF="$ROOT_DIR/dotfiles/.config/tmux/tmux.conf"
-NVIM_INIT="$ROOT_DIR/dotfiles/.config/nvim/init.lua"
-ZSH_TOOLS="$ROOT_DIR/dotfiles/.config/zsh/20-tools.zsh"
-DOTFILES_SETUP="$ROOT_DIR/scripts/setup-dotfiles.sh"
 
-# ─── Warp theme ─────────────────────────────────────────────────────
-it "should ship Warp catppuccin_mocha theme YAML with required fields"
-assert_file_exists "$WARP_THEME" "Warp Catppuccin Mocha YAML should exist"
+it "should preserve Catppuccin Mocha Warp YAML as a one-click fallback"
+assert_file_exists "$WARP_THEME" "Mocha YAML should remain deployed for fallback selection"
 assert_file_contains "$WARP_THEME" "name: 'Catppuccin Mocha'" "YAML must declare name (required by Warp)"
 assert_file_contains "$WARP_THEME" "background: '#1e1e2e'" "background should be Mocha base"
 assert_file_contains "$WARP_THEME" "foreground: '#cdd6f4'" "foreground should be Mocha text"
-
-it "should deploy Warp themes via setup-dotfiles.sh (UI selection required)"
-assert_file_contains "$DOTFILES_SETUP" 'dotfiles/.warp/themes' "setup-dotfiles.sh should reference Warp themes source"
-assert_file_contains "$DOTFILES_SETUP" "Settings → Appearance → Themes" "should instruct user to pick theme via Warp UI"
-
-# ─── tmux ────────────────────────────────────────────────────────────
-it "should declare catppuccin/tmux plugin and Mocha flavor"
-assert_file_contains "$TMUX_CONF" "@plugin 'catppuccin/tmux" "catppuccin/tmux plugin should be declared"
-assert_file_contains "$TMUX_CONF" "@catppuccin_flavor 'mocha'" "tmux flavor should be mocha"
-assert_file_contains "$TMUX_CONF" "@catppuccin_status_session" "status-left should embed catppuccin session module"
-
-# ─── nvim ────────────────────────────────────────────────────────────
-it "should install catppuccin via vim.pack and apply mocha"
-assert_file_contains "$NVIM_INIT" "vim.pack.add" "init.lua should use vim.pack.add"
-assert_file_contains "$NVIM_INIT" "https://github.com/catppuccin/nvim" "init.lua should reference catppuccin/nvim"
-assert_file_contains "$NVIM_INIT" 'flavour = "mocha"' "catppuccin.setup should pick mocha flavour"
-assert_file_contains "$NVIM_INIT" 'colorscheme, "catppuccin-mocha"' "should set catppuccin-mocha colorscheme"
-
-it "should apply catppuccin-mocha when nvim loads"
-if command -v nvim >/dev/null 2>&1 && find "$HOME/.local/share/nvim/site/pack" -maxdepth 4 -type d -name "catppuccin*" 2>/dev/null | grep -q .; then
-    # Prefix-tag the report so we can grep past init.lua's load-success print()
-    scheme=$(nvim --headless -c 'lua print("CSCHEME:" .. tostring(vim.g.colors_name))' -c 'qa!' 2>&1 | grep -E '^CSCHEME:' | head -1)
-    assert_contains "$scheme" "catppuccin-mocha" "live nvim should report catppuccin-mocha colorscheme"
-else
-    echo "  (catppuccin not yet installed via vim.pack — skipping live colorscheme check)"
-fi
-
-# ─── bat + fzf ───────────────────────────────────────────────────────
-it "should set BAT_THEME to Catppuccin Mocha"
-assert_file_contains "$ZSH_TOOLS" 'BAT_THEME="Catppuccin Mocha"' "bat theme should be Catppuccin Mocha"
-
-it "should override FZF_DEFAULT_OPTS with the Mocha palette"
-assert_file_contains "$ZSH_TOOLS" "bg:#1e1e2e" "fzf bg should be Mocha base"
-assert_file_contains "$ZSH_TOOLS" "fg:#cdd6f4" "fzf fg should be Mocha text"
-assert_file_contains "$ZSH_TOOLS" "hl:#f38ba8" "fzf highlight should be Mocha red/pink"
-
-it "should expose the bat theme name when bat is installed"
-if command -v bat >/dev/null 2>&1; then
-    bat_themes=$(bat --list-themes 2>/dev/null | grep -F "Catppuccin Mocha" || true)
-    assert_not_empty "$bat_themes" "bat should know the Catppuccin Mocha theme"
-else
-    echo "  (bat not installed — skipping live theme check)"
-fi
 
 summarize

--- a/tests/unit/test_theme_solarized.sh
+++ b/tests/unit/test_theme_solarized.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Tests for the Solarized Dark coordinated theme across Warp / tmux / nvim
+# / bat / fzf. Asserts on the repo source-of-truth files and (when the live
+# tool is present) verifies the deployed config picks the correct palette.
+# Catppuccin Mocha YAML is intentionally preserved as a one-click Warp
+# fallback; only the *active* layers (nvim/tmux/bat/fzf) are required to be
+# Solarized.
+
+source "$(dirname "$0")/../test_framework.sh"
+
+if [[ -f "$ROOT_DIR/lib/common.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/lib/common.sh"
+fi
+
+describe "Solarized Dark Coordinated Theme"
+
+WARP_THEME="$ROOT_DIR/dotfiles/.warp/themes/solarized_dark.yml"
+TMUX_CONF="$ROOT_DIR/dotfiles/.config/tmux/tmux.conf"
+NVIM_INIT="$ROOT_DIR/dotfiles/.config/nvim/init.lua"
+ZSH_TOOLS="$ROOT_DIR/dotfiles/.config/zsh/20-tools.zsh"
+DOTFILES_SETUP="$ROOT_DIR/scripts/setup-dotfiles.sh"
+
+# ─── Warp theme ─────────────────────────────────────────────────────
+it "should ship Warp solarized_dark theme YAML with required fields"
+assert_file_exists "$WARP_THEME" "Warp Solarized Dark YAML should exist"
+assert_file_contains "$WARP_THEME" "name: 'Solarized Dark'" "YAML must declare name (required by Warp)"
+assert_file_contains "$WARP_THEME" "background: '#002b36'" "background should be Solarized base03"
+assert_file_contains "$WARP_THEME" "foreground: '#839496'" "foreground should be Solarized base0"
+assert_file_contains "$WARP_THEME" "accent: '#268bd2'" "accent should be Solarized blue"
+
+it "should deploy Warp themes via setup-dotfiles.sh (UI selection required)"
+assert_file_contains "$DOTFILES_SETUP" 'dotfiles/.warp/themes' "setup-dotfiles.sh should reference Warp themes source"
+assert_file_contains "$DOTFILES_SETUP" "Settings → Appearance → Themes" "should instruct user to pick theme via Warp UI"
+
+# ─── tmux ────────────────────────────────────────────────────────────
+it "should hand-roll Solarized Dark status line (no catppuccin/tmux plugin)"
+assert_file_contains "$TMUX_CONF" "bg=#073642,fg=#839496" "status-style should use Solarized base02 bg + base0 fg"
+assert_file_contains "$TMUX_CONF" "bg=#268bd2" "session/host accent should be Solarized blue"
+assert_file_contains "$TMUX_CONF" "bg=#b58900" "current-window highlight should be Solarized yellow"
+assert_file_contains "$TMUX_CONF" "pane-active-border-style 'fg=#268bd2'" "active pane border should be Solarized blue"
+tmux_conf_content=$(cat "$TMUX_CONF")
+assert_not_contains "$tmux_conf_content" "@plugin 'catppuccin/tmux" "catppuccin/tmux plugin should be removed"
+assert_not_contains "$tmux_conf_content" "@catppuccin_flavor" "catppuccin flavor variable should be removed"
+
+# ─── nvim ────────────────────────────────────────────────────────────
+it "should install solarized.nvim via vim.pack and apply dark variant"
+assert_file_contains "$NVIM_INIT" "vim.pack.add" "init.lua should use vim.pack.add"
+assert_file_contains "$NVIM_INIT" "https://github.com/maxmx03/solarized.nvim" "init.lua should reference maxmx03/solarized.nvim"
+assert_file_contains "$NVIM_INIT" 'vim.o.background = "dark"' "should set background to dark before colorscheme"
+assert_file_contains "$NVIM_INIT" 'colorscheme, "solarized"' "should set solarized colorscheme"
+nvim_init_content=$(cat "$NVIM_INIT")
+assert_not_contains "$nvim_init_content" "catppuccin/nvim" "old catppuccin plugin reference should be gone"
+assert_not_contains "$nvim_init_content" "catppuccin-mocha" "old catppuccin-mocha colorscheme reference should be gone"
+
+it "should apply solarized when nvim loads"
+if command -v nvim >/dev/null 2>&1 && find "$HOME/.local/share/nvim/site/pack" -maxdepth 4 -type d -iname "solarized*" 2>/dev/null | grep -q .; then
+    # Prefix-tag the report so we can grep past init.lua's load-success print()
+    scheme=$(nvim --headless -c 'lua print("CSCHEME:" .. tostring(vim.g.colors_name))' -c 'qa!' 2>&1 | grep -E '^CSCHEME:' | head -1)
+    assert_contains "$scheme" "solarized" "live nvim should report solarized colorscheme"
+else
+    echo "  (solarized.nvim not yet installed via vim.pack — skipping live colorscheme check)"
+fi
+
+# ─── bat + fzf ───────────────────────────────────────────────────────
+it "should set BAT_THEME to Solarized (dark)"
+assert_file_contains "$ZSH_TOOLS" 'BAT_THEME="Solarized (dark)"' "bat theme should be Solarized (dark)"
+
+it "should override FZF_DEFAULT_OPTS with the Solarized Dark palette"
+assert_file_contains "$ZSH_TOOLS" "bg:#002b36" "fzf bg should be Solarized base03"
+assert_file_contains "$ZSH_TOOLS" "fg:#839496" "fzf fg should be Solarized base0"
+assert_file_contains "$ZSH_TOOLS" "hl:#b58900" "fzf highlight should be Solarized yellow"
+assert_file_contains "$ZSH_TOOLS" "pointer:#268bd2" "fzf pointer should be Solarized blue"
+
+it "should expose the bat theme name when bat is installed"
+if command -v bat >/dev/null 2>&1; then
+    bat_themes=$(bat --list-themes 2>/dev/null | grep -F "Solarized (dark)" || true)
+    assert_not_empty "$bat_themes" "bat should know the Solarized (dark) theme"
+else
+    echo "  (bat not installed — skipping live theme check)"
+fi
+
+summarize


### PR DESCRIPTION
## Summary

Swaps the active palette from Catppuccin Mocha (#136) to Solarized Dark across nvim/tmux/bat/fzf and adds the corresponding Warp theme YAML. Stacked on `feat/tmux-tpm-baseline` like #136 was.

| Layer | Change |
|---|---|
| **Warp** | New `dotfiles/.warp/themes/solarized_dark.yml` with Ethan Schoonover's canonical 16-color palette. `setup-dotfiles.sh` already globs `*.yml` so the YAML auto-deploys; flip via Settings → Appearance → Themes. |
| **tmux** | Drops `catppuccin/tmux` plugin (no equivalent maintained Solarized tmux plugin exists). Hand-rolled status line: base02 bg + base0 fg, blue session/host accent, yellow current-window highlight. ~15 lines, no external dep. |
| **nvim** | `vim.pack.add{ maxmx03/solarized.nvim }` (modern, well-maintained Solarized port). `vim.o.background = "dark"` + `:colorscheme solarized`. Same `vim.pack` pattern as before — no plugin manager introduced. |
| **bat** | `BAT_THEME="Solarized (dark)"` (built into bat — both Solarized variants ship). |
| **fzf** | `FZF_DEFAULT_OPTS` palette overrides regenerated for Solarized Dark (base03 bg, base0 fg, yellow hl, blue pointer). |

## Why Solarized Dark?

Marvin asked for alternatives to Mocha and named Solarized as one he likes. Solarized has the best cross-stack port coverage after Catppuccin (Warp, tmux community ports, nvim, bat, fzf, delta, starship, eza, et al.) and its scientifically tuned palette is the gold standard for low-eye-strain terminals. Dark variant matches the prior "dark theme" starting point; flipping to Light is a one-line change in `init.lua` + `BAT_THEME` env + Warp YAML.

## Mocha YAML preserved as fallback

`dotfiles/.warp/themes/catppuccin_mocha.yml` is intentionally kept so the user can flip back to Mocha in one click via Warp Settings → Appearance. The slimmed `tests/unit/test_theme_catppuccin.sh` now guards that fallback YAML stays palette-correct (4 assertions). Same precedent as #136 preserving `cyber_wave` as a Warp built-in.

## Out of scope (deliberate)

- **delta**, **starship**, **eza**/`LS_COLORS` — also have Solarized ports; left as a follow-up if the full sweep is wanted. Keeping this PR scoped to the layers #136 touched.
- **Other nvim plugins** — only the colorscheme. (`vim.pack` is the door, not the room.)

## Test plan

- [x] `tests/unit/test_theme_solarized.sh` — 25 assertions: Warp YAML palette (base03/base0/blue), `setup-dotfiles.sh` wiring, tmux hand-rolled status (base02 bg, blue accent, yellow current-window) + catppuccin removal, nvim `vim.pack` + `solarized` colorscheme + catppuccin removal, `BAT_THEME`, FZF Solarized hex codes, live `bat --list-themes` includes "Solarized (dark)"
- [x] `tests/unit/test_theme_catppuccin.sh` — 4 assertions: Mocha YAML remains deployed as one-click fallback
- [x] `shellcheck --severity=warning` — clean on new test files; no new warnings on touched files vs baseline
- [ ] Visual smoke after Warp restart — terminal bg flips to base03 (`#002b36`), tmux status bar renders Solarized colors, `bat README.md` highlights in Solarized syntax, nvim `:colorscheme solarized` applies

## Migration note

After merge, run `./scripts/setup-dotfiles.sh` to redeploy. Then in Warp: Settings → Appearance → Themes → "Solarized Dark". For nvim, `solarized.nvim` installs on next launch via `vim.pack`. tmux config picks up via `prefix + r`. `BAT_THEME` picks up on next zsh.

To roll back: pick "Catppuccin Mocha" in Warp UI; revert this commit to restore the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)