### PR TITLE
chore: redact internal codenames from public-repo references

### DIFF
--- a/.claude/agents/boardroom.md
+++ b/.claude/agents/boardroom.md
@@ -82,7 +82,7 @@ Before scoring advisors for selection, check whether the roster (sitting + candi
 1. **Decompose the topic into 2-4 domain dimensions.** Examples:
    - Topic: "audit my agentic system" → dimensions: *engineering craft / complexity discipline*, *AI agent orchestration*, *personal knowledge infrastructure*, *leverage vs over-engineering*
    - Topic: "should I expand IHW into chiropractic services?" → dimensions: *healthcare service-business economics*, *small-business expansion*, *brand extension*, *capital allocation*
-   - Topic: "Netflix exit timing" → dimensions: *career arc inflection*, *equity-vesting decisions*, *leverage architecture*, *personal-brand transition*
+   - Topic: "senior tech leadership exit timing" → dimensions: *career arc inflection*, *equity-vesting decisions*, *leverage architecture*, *personal-brand transition*
 2. **For each dimension, scan the roster** (sitting + candidates) for at least one voice that explicitly covers it via `when-to-summon` or `value-add`. Coverage requires substantive match, not just adjacent vocabulary.
 3. **Flag dimensions with no covering voice** as roster gaps.
 

--- a/.claude/skills/decision-lab/COUNCIL.md
+++ b/.claude/skills/decision-lab/COUNCIL.md
@@ -439,7 +439,7 @@ Curated roster of operating-wisdom voices. The boardroom agent reads this file t
   source: Matthew Ball
   category: writers-analysts
   status: candidate
-  value-add: Definitive analyst on media, gaming, and streaming economics — directly relevant to DVX work
+  value-add: Definitive analyst on media, gaming, and streaming economics
 - id: finance-meets-tech
   source: Byrne Hobart
   category: writers-analysts

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -49,8 +49,9 @@ When issues found, report as:
 ### Allowlist (public-OK references — do NOT flag)
 
 - "Netflix" as employer reference
-- Marvin's public role: "Sr Engineering Manager", "DVX Live UI", "DVX Live"
+- Marvin's LinkedIn-public role: "Engineering Manager", "Live Viewing Experiences" (team)
 - Public initiatives Netflix has announced (live streaming launch dates publicly disclosed; SDUI publicly published)
+- Marvin's preference: prefer functional descriptors ("live streaming product experiences") over team names — team names change with reorgs
 - Public talks Marvin has given (titles, venues, conference names)
 - Open-source projects Marvin maintains
 - General industry concepts ("server-driven UI", "platform engineering")


### PR DESCRIPTION
## Summary

Three surgical redactions to strip never-publicized internal identifiers from this **public** repo:

| File | Before | After |
|---|---|---|
| \`.claude/agents/boardroom.md:85\` | Example topic: \"Netflix exit timing\" | \"senior tech leadership exit timing\" (generic, not Marvin-personal) |
| \`.claude/skills/security-review/SKILL.md:52\` | Allowlist: \"DVX Live UI\", \"DVX Live\" as Marvin's public role | \"Engineering Manager\", \"Live Viewing Experiences\" (LinkedIn-public team) |
| \`.claude/skills/decision-lab/COUNCIL.md:442\` | \"... directly relevant to DVX work\" | (dropped qualifier) |

## Why these matter

This repo is **public**. The original references named:

1. A sensitive personal topic (Marvin contemplating Netflix exit)
2. Internal team identifiers (\"DVX Live UI\", \"DVX Live\") that were INCORRECTLY listed in the security-review allowlist as if they were LinkedIn-public
3. An internal codename in an advisor description

The SKILL.md fix is the most important — it was actively *encoding the wrong policy* by claiming \"DVX Live UI\" was safe to publish.

## Editorial principle added

> Prefer functional descriptors over team names. Team names change with reorgs.

Added to the SKILL.md allowlist as guidance for future security-review runs.

## Test plan

- [x] Diff is surgical (3 files, +4/-3 lines)
- [x] No functional changes to skill/agent behavior
- [x] All redactions are reversible if reviewers want different phrasing